### PR TITLE
MAE-321: Update extension name / key to match the project extension key

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,12 +41,12 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicrm.members-only-events
+          path: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.membersonlyevent
 
       - name: Installing Members Only Event extension
         working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}
-        run: cv en com.compucorp.membersonlyevent
+        run: cv en uk.co.compucorp.membersonlyevent
 
       - name: Run phpunit tests
-        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.civicrm.members-only-events
+        working-directory: ${{ env.CIVICRM_EXTENSIONS_DIR }}/uk.co.compucorp.membersonlyevent
         run: phpunit5


### PR DESCRIPTION
## Overview
This PR is to update extension key from com.compucorp.membersonlyevent to uk.co.compucorp.membersonlyevent as the extension key is changed to reflect that it is updated in the workflow file.
