### PR TITLE
PSHEASSN-507: Purchase membership button available for site visitors 

### DIFF
--- a/membersonlyevent.php
+++ b/membersonlyevent.php
@@ -243,16 +243,7 @@ function _membersonlyevent_is_tab_valid($eventID) {
 function _membersonlyevent_civicrm_pageRun_CRM_Event_Page_EventInfo(&$page) {
   $eventID = $page->_id;
 
-  if (_membersonly_is_event_for_members_only($eventID)) {
-    $session = CRM_Core_Session::singleton();
-    $statusMessages = $session->get('status');
-    foreach ($statusMessages as $k => $msg) {
-      if (strpos($msg['text'], 'register another participant')) {
-        $statusMessages[$k]['text'] = ts("It looks like you are already registered for this event. If you want to change your registration, or you feel that you've gotten this message in error, please contact the site administrator.");
-      }
-    }
-    $session->set('status', $statusMessages);
-  }
+  _membersonlyevent_event_info_page_session_handler($eventId);
 
   $userHasEventAccess = _membersonlyevent_user_has_event_access($eventID);
   if ($userHasEventAccess) {
@@ -269,6 +260,32 @@ function _membersonlyevent_civicrm_pageRun_CRM_Event_Page_EventInfo(&$page) {
   else {
     _membersonlyevent_handle_access_denied_for_logged_users($eventID);
   }
+}
+
+/**
+ * Handle session message if the user is trying
+ * to register another participant.
+ *
+ * @param int $eventID
+ *
+ */
+function _membersonlyevent_event_info_page_session_handler($eventID) {
+  if (!_membersonly_is_event_for_members_only($eventID)) {
+    return;
+  }
+
+  $session = CRM_Core_Session::singleton();
+  $statusMessages = $session->get('status');
+  if (empty($statusMessages)) {
+    return;
+  }
+
+  foreach ($statusMessages as $k => $msg) {
+    if (strpos($msg['text'], 'register another participant')) {
+      $statusMessages[$k]['text'] = ts("It looks like you are already registered for this event. If you want to change your registration, or you feel that you've gotten this message in error, please contact the site administrator.");
+    }
+  }
+  $session->set('status', $statusMessages);
 }
 
 /**

--- a/membersonlyevent.php
+++ b/membersonlyevent.php
@@ -243,7 +243,7 @@ function _membersonlyevent_is_tab_valid($eventID) {
 function _membersonlyevent_civicrm_pageRun_CRM_Event_Page_EventInfo(&$page) {
   $eventID = $page->_id;
 
-  _membersonlyevent_event_info_page_session_handler($eventId);
+  _membersonlyevent_event_info_page_session_handler($eventID);
 
   $userHasEventAccess = _membersonlyevent_user_has_event_access($eventID);
   if ($userHasEventAccess) {
@@ -253,13 +253,8 @@ function _membersonlyevent_civicrm_pageRun_CRM_Event_Page_EventInfo(&$page) {
 
   _membersonlyevent_hide_event_info_page_register_button();
 
-  $userLoggedIn = CRM_Core_Session::getLoggedInContactID();
-  if (!$userLoggedIn) {
-    _membersonlyevent_handle_access_denied_for_guest_users();
-  }
-  else {
-    _membersonlyevent_handle_access_denied_for_logged_users($eventID);
-  }
+  _membersonlyevent_handle_access_option_for_user($eventID);
+
 }
 
 /**
@@ -451,27 +446,25 @@ function _membersonlyevent_hide_event_info_page_register_button() {
 }
 
 /**
- * Handles the case when the guest
- * user does not have permission to access
- * the event info page.
+ * Handles access options for logged / anonymous user.
+ *
+ * @param $eventID
  *
  */
-function _membersonlyevent_handle_access_denied_for_guest_users() {
-  $loginURL = CRM_Core_Config::singleton()->userSystem->getLoginURL();
-  _membersonlyevent_add_action_button_to_event_info_page($loginURL, 'Login to register');
-}
-
-/**
- * Handles the case when the logged-in
- * user does not have permission to access
- * the event info page.
- *
- * @param int $eventID
- */
-function _membersonlyevent_handle_access_denied_for_logged_users($eventID) {
+function _membersonlyevent_handle_access_option_for_user($eventID) {
   $membersOnlyEvent = MembersOnlyEvent::getMembersOnlyEvent($eventID);
   if ($membersOnlyEvent->purchase_membership_button) {
     _membersonlyevent_add_membership_purchase_button_to_event_info_page($membersOnlyEvent);
+    $userLoggedIn = CRM_Core_Session::getLoggedInContactID();
+    if ($userLoggedIn) {
+      return;
+    }
+    $loginURL = CRM_Core_Config::singleton()->userSystem->getLoginURL();
+    $infoText = 'This event is for members only, if you have a current, pending or former membership
+                 please log in before purchase membership. If you are not a current member you will be charged
+                 an additional membership fee. <a href="' . $loginURL . '">Click here to login </a>';
+    CRM_Core_Session::setStatus(ts($infoText));
+
   }
   else {
     // Purchase membership button is disabled, so we will just show the configured notice message


### PR DESCRIPTION
## Overview

This PR is to provide the way members only event extension handles Event Info page when an anonymous user or a logged-in user access Event Info page without having right membership(s) and the members only event configuration is configured to "Allowed Membership Types Provide Purchase Membership Button when access denied"

## Before

**An anonymous user**

When visiting event info page, the anonymous see the Login to register button

![Screenshot from 2020-11-11 14-13-16](https://user-images.githubusercontent.com/208713/98821938-171cfe80-2428-11eb-83bf-5fdb29488f8f.png)

**Logged in user**

When visiting event info page, the user that does not have right membership, will see the button purchase button. 

![Screenshot from 2020-11-11 14-15-22](https://user-images.githubusercontent.com/208713/98822153-5f3c2100-2428-11eb-8f18-52c1b8602394.png)


## After

An anonymous user

When visiting event info page, the anonymous will see, will see the button purchase button.  and intro text indicate that the event is member only event. 

![Screenshot from 2020-11-11 14-16-06](https://user-images.githubusercontent.com/208713/98822230-7bd85900-2428-11eb-80b1-080152841c55.png)

Logged in user

When visiting event info page,  the user that does not have right membership, will see the button purchase button. 

![Screenshot from 2020-11-11 14-17-02](https://user-images.githubusercontent.com/208713/98822318-9a3e5480-2428-11eb-9362-0929cd7c8fb3.png)

