### PR TITLE
MAE-404: Menu changes

### DIFF
--- a/membersonlyevent.civix.php
+++ b/membersonlyevent.civix.php
@@ -3,35 +3,116 @@
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
- * (Delegated) Implementation of hook_civicrm_config
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_MembersOnlyEvent_ExtensionUtil {
+  const SHORT_NAME = 'membersonlyevent';
+  const LONG_NAME = 'uk.co.compucorp.membersonlyevent';
+  const CLASS_PREFIX = 'CRM_MembersOnlyEvent';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_MembersOnlyEvent_ExtensionUtil as E;
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
 function _membersonlyevent_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
-  if ($configured) return;
+  if ($configured) {
+    return;
+  }
   $configured = TRUE;
 
   $template =& CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
+  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
-  if ( is_array( $template->template_dir ) ) {
-      array_unshift( $template->template_dir, $extDir );
-  } else {
-      $template->template_dir = array( $extDir, $template->template_dir );
+  if (is_array($template->template_dir)) {
+    array_unshift($template->template_dir, $extDir);
+  }
+  else {
+    $template->template_dir = [$extDir, $template->template_dir];
   }
 
-  $include_path = $extRoot . PATH_SEPARATOR . get_include_path( );
-  set_include_path( $include_path );
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_xmlMenu
+ * (Delegated) Implements hook_civicrm_xmlMenu().
  *
  * @param $files array(string)
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
  */
 function _membersonlyevent_civix_civicrm_xmlMenu(&$files) {
   foreach (_membersonlyevent_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
@@ -40,67 +121,83 @@ function _membersonlyevent_civix_civicrm_xmlMenu(&$files) {
 }
 
 /**
- * Implementation of hook_civicrm_install
+ * Implements hook_civicrm_install().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _membersonlyevent_civix_civicrm_install() {
   _membersonlyevent_civix_civicrm_config();
   if ($upgrader = _membersonlyevent_civix_upgrader()) {
-    return $upgrader->onInstall();
+    $upgrader->onInstall();
   }
 }
 
 /**
- * Implementation of hook_civicrm_uninstall
+ * Implements hook_civicrm_postInstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
+ */
+function _membersonlyevent_civix_civicrm_postInstall() {
+  _membersonlyevent_civix_civicrm_config();
+  if ($upgrader = _membersonlyevent_civix_upgrader()) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
+      $upgrader->onPostInstall();
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_uninstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
 function _membersonlyevent_civix_civicrm_uninstall() {
   _membersonlyevent_civix_civicrm_config();
   if ($upgrader = _membersonlyevent_civix_upgrader()) {
-    return $upgrader->onUninstall();
+    $upgrader->onUninstall();
   }
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_enable
+ * (Delegated) Implements hook_civicrm_enable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _membersonlyevent_civix_civicrm_enable() {
   _membersonlyevent_civix_civicrm_config();
   if ($upgrader = _membersonlyevent_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onEnable'))) {
-      return $upgrader->onEnable();
+    if (is_callable([$upgrader, 'onEnable'])) {
+      $upgrader->onEnable();
     }
   }
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_disable
+ * (Delegated) Implements hook_civicrm_disable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
+ * @return mixed
  */
 function _membersonlyevent_civix_civicrm_disable() {
   _membersonlyevent_civix_civicrm_config();
   if ($upgrader = _membersonlyevent_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onDisable'))) {
-      return $upgrader->onDisable();
+    if (is_callable([$upgrader, 'onDisable'])) {
+      $upgrader->onDisable();
     }
   }
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_upgrade
+ * (Delegated) Implements hook_civicrm_upgrade().
  *
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _membersonlyevent_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _membersonlyevent_civix_upgrader()) {
@@ -112,30 +209,32 @@ function _membersonlyevent_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = N
  * @return CRM_MembersOnlyEvent_Upgrader
  */
 function _membersonlyevent_civix_upgrader() {
-  if (!file_exists(__DIR__.'/CRM/MembersOnlyEvent/Upgrader.php')) {
+  if (!file_exists(__DIR__ . '/CRM/MembersOnlyEvent/Upgrader.php')) {
     return NULL;
-  } else {
+  }
+  else {
     return CRM_MembersOnlyEvent_Upgrader_Base::instance();
   }
 }
 
 /**
- * Search directory tree for files which match a glob pattern
+ * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
  * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
  *
- * @param $dir string, base dir
- * @param $pattern string, glob pattern, eg "*.txt"
- * @return array(string)
+ * @param string $dir base dir
+ * @param string $pattern , glob pattern, eg "*.txt"
+ *
+ * @return array
  */
 function _membersonlyevent_civix_find_files($dir, $pattern) {
-  if (is_callable(array('CRM_Utils_File', 'findFiles'))) {
+  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
     return CRM_Utils_File::findFiles($dir, $pattern);
   }
 
-  $todos = array($dir);
-  $result = array();
+  $todos = [$dir];
+  $result = [];
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_membersonlyevent_civix_glob("$subdir/$pattern") as $match) {
@@ -146,8 +245,9 @@ function _membersonlyevent_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
-        } elseif (is_dir($path)) {
+        if ($entry[0] == '.') {
+        }
+        elseif (is_dir($path)) {
           $todos[] = $path;
         }
       }
@@ -156,20 +256,25 @@ function _membersonlyevent_civix_find_files($dir, $pattern) {
   }
   return $result;
 }
+
 /**
- * (Delegated) Implementation of hook_civicrm_managed
+ * (Delegated) Implements hook_civicrm_managed().
  *
  * Find any *.mgd.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
  */
 function _membersonlyevent_civix_civicrm_managed(&$entities) {
   $mgdFiles = _membersonlyevent_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
   foreach ($mgdFiles as $file) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = 'uk.co.compucorp.membersonlyevent';
+        $e['module'] = E::LONG_NAME;
+      }
+      if (empty($e['params']['version'])) {
+        $e['params']['version'] = '3';
       }
       $entities[] = $e;
     }
@@ -177,13 +282,13 @@ function _membersonlyevent_civix_civicrm_managed(&$entities) {
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_caseTypes
+ * (Delegated) Implements hook_civicrm_caseTypes().
  *
  * Find any and return any files matching "xml/case/*.xml"
  *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _membersonlyevent_civix_civicrm_caseTypes(&$caseTypes) {
   if (!is_dir(__DIR__ . '/xml/case')) {
@@ -194,14 +299,57 @@ function _membersonlyevent_civix_civicrm_caseTypes(&$caseTypes) {
     $name = preg_replace('/\.xml$/', '', basename($file));
     if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
       $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      CRM_Core_Error::fatal($errorMessage);
-      // throw new CRM_Core_Exception($errorMessage);
+      throw new CRM_Core_Exception($errorMessage);
     }
-    $caseTypes[$name] = array(
-      'module' => 'uk.co.compucorp.membersonlyevent',
+    $caseTypes[$name] = [
+      'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
-    );
+    ];
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_angularModules().
+ *
+ * Find any and return any files matching "ang/*.ang.php"
+ *
+ * Note: This hook only runs in CiviCRM 4.5+.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
+ */
+function _membersonlyevent_civix_civicrm_angularModules(&$angularModules) {
+  if (!is_dir(__DIR__ . '/ang')) {
+    return;
+  }
+
+  $files = _membersonlyevent_civix_glob(__DIR__ . '/ang/*.ang.php');
+  foreach ($files as $file) {
+    $name = preg_replace(':\.ang\.php$:', '', basename($file));
+    $module = include $file;
+    if (empty($module['ext'])) {
+      $module['ext'] = E::LONG_NAME;
+    }
+    $angularModules[$name] = $module;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_themes().
+ *
+ * Find any and return any files matching "*.theme.php"
+ */
+function _membersonlyevent_civix_civicrm_themes(&$themes) {
+  $files = _membersonlyevent_civix_glob(__DIR__ . '/*.theme.php');
+  foreach ($files as $file) {
+    $themeMeta = include $file;
+    if (empty($themeMeta['name'])) {
+      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+    }
+    if (empty($themeMeta['ext'])) {
+      $themeMeta['ext'] = E::LONG_NAME;
+    }
+    $themes[$themeMeta['name']] = $themeMeta;
   }
 }
 
@@ -215,46 +363,47 @@ function _membersonlyevent_civix_civicrm_caseTypes(&$caseTypes) {
  *
  * @link http://php.net/glob
  * @param string $pattern
- * @return array, possibly empty
+ *
+ * @return array
  */
 function _membersonlyevent_civix_glob($pattern) {
   $result = glob($pattern);
-  return is_array($result) ? $result : array();
+  return is_array($result) ? $result : [];
 }
 
 /**
- * Inserts a navigation menu item at a given place in the hierarchy
+ * Inserts a navigation menu item at a given place in the hierarchy.
  *
- * $menu - menu hierarchy
- * $path - path where insertion should happen (ie. Administer/System Settings)
- * $item - menu you need to insert (parent/child attributes will be filled for you)
- * $parentId - used internally to recurse in the menu structure
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
  */
-function _membersonlyevent_civix_insert_navigation_menu(&$menu, $path, $item, $parentId = NULL) {
-  static $navId;
-
+function _membersonlyevent_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    if (!$navId) $navId = CRM_Core_DAO::singleValueQuery("SELECT max(id) FROM civicrm_navigation");
-    $navId ++;
-    $menu[$navId] = array (
-      'attributes' => array_merge($item, array(
+    $menu[] = [
+      'attributes' => array_merge([
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-        'parentID'   => $parentId,
-        'navID'      => $navId,
-      ))
-    );
-    return true;
-  } else {
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
     // Find an recurse into the next level down
-    $found = false;
+    $found = FALSE;
     $path = explode('/', $path);
     $first = array_shift($path);
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
-        if (!$entry['child']) $entry['child'] = array();
-        $found = _membersonlyevent_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _membersonlyevent_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
@@ -262,17 +411,78 @@ function _membersonlyevent_civix_insert_navigation_menu(&$menu, $path, $item, $p
 }
 
 /**
- * (Delegated) Implementation of hook_civicrm_alterSettingsFolders
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _membersonlyevent_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _membersonlyevent_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _membersonlyevent_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _membersonlyevent_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _membersonlyevent_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _membersonlyevent_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_alterSettingsFolders().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
  */
 function _membersonlyevent_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) return;
-  $configured = TRUE;
-
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if(is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+function _membersonlyevent_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, [
+    'CRM_MembersOnlyEvent_DAO_EventMembershipType' => [
+      'name' => 'EventMembershipType',
+      'class' => 'CRM_MembersOnlyEvent_DAO_EventMembershipType',
+      'table' => 'membersonlyevent_event_membership_type',
+    ],
+    'CRM_MembersOnlyEvent_DAO_MembersOnlyEvent' => [
+      'name' => 'MembersOnlyEvent',
+      'class' => 'CRM_MembersOnlyEvent_DAO_MembersOnlyEvent',
+      'table' => 'membersonlyevent',
+    ],
+  ]);
 }

--- a/membersonlyevent.php
+++ b/membersonlyevent.php
@@ -198,9 +198,17 @@ function membersonlyevent_civicrm_preProcess($formName, &$form) {
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_navigationMenu
  */
-function membersonlyevent_civicrm_navigationMenu(&$params) {
-  _membersonlyevent_add_configurations_menu($params);
-}
+function membersonlyevent_civicrm_navigationMenu(&$menu) {
+  $membersonlyeventMenu = [
+    'label' => ts('Members Only Event Extension Configurations'),
+    'name' => 'membersonlyevent_configurations',
+    'url' => 'civicrm/admin/membersonlyevent',
+    'permission' => 'administer CiviCRM,access CiviEvent',
+    'operator' => NULL,
+    'separator' => NULL,
+  ];
+
+  _membersonlyevent_civix_insert_navigation_menu($menu, 'Administer/CiviEvent', $membersonlyeventMenu);}
 
 //----------------------------------------------------------------------------//
 //                               Helper Functions                             //
@@ -551,35 +559,6 @@ function _membersonlyevent_civicrm_preProcess_CRM_Event_Form_Registration_Regist
       CRM_Utils_System::redirect($url);
       $form->_skipDupeRegistrationCheck = TRUE;
     }
-  }
-}
-
-/**
- * Adds `Members-Only Event Extension Configurations` menu
- * item under `Administer` top-level menu item.
- *
- * @param $params
- */
-function _membersonlyevent_add_configurations_menu(&$params) {
-  $administerMenuId = CRM_Core_DAO::getFieldValue('CRM_Core_BAO_Navigation', 'Administer', 'id', 'name');
-  if ($administerMenuId) {
-    // get the maximum key under administer menu
-    $maxAdminMenuKey = max(array_keys($params[$administerMenuId]['child']));
-    $nextAdminMenuKey = $maxAdminMenuKey + 1;
-    $params[$administerMenuId]['child'][$nextAdminMenuKey] = array(
-      'attributes' => array(
-        'label' => ts('Members-Only Event Extension Configurations'),
-        'name' => 'membersonlyevent_configurations',
-        'url' => 'civicrm/admin/membersonlyevent',
-        'permission' => 'administer CiviCRM,access CiviEvent',
-        'operator' => NULL,
-        'separator' => 1,
-        'parentID' => $administerMenuId,
-        'navID' => $nextAdminMenuKey,
-        'active' => 1,
-      ),
-      'child' => NULL,
-    );
   }
 }
 

--- a/membersonlyevent.php
+++ b/membersonlyevent.php
@@ -208,7 +208,8 @@ function membersonlyevent_civicrm_navigationMenu(&$menu) {
     'separator' => NULL,
   ];
 
-  _membersonlyevent_civix_insert_navigation_menu($menu, 'Administer/CiviEvent', $membersonlyeventMenu);}
+  _membersonlyevent_civix_insert_navigation_menu($menu, 'Administer/CiviEvent', $membersonlyeventMenu);
+}
 
 //----------------------------------------------------------------------------//
 //                               Helper Functions                             //


### PR DESCRIPTION
## Overview

This PR is to move Members only event configuration menu from locating under Administer to Administer -> CiviEvent.

## Before
![Screenshot from 2020-11-13 15-41-32](https://user-images.githubusercontent.com/208713/99552053-7c3a9c00-29b4-11eb-9977-7f02d530b32f.png)

## After
![Screenshot from 2020-11-18 15-38-02](https://user-images.githubusercontent.com/208713/99551960-6331eb00-29b4-11eb-98d6-ea1c003cef8d.png)

## Technical Details

Since the extension was written years ago and the menu was added using legacy method. See. https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu/, the menu has been re-written to use the recommended method, in order to achieve this, membersonlyevent.civix.php needed to be updated. 

membersonlyevent.civix.php file was re-generated automatically by using civix command. 