### PR TITLE
PSHEASSN-518:  Capitalise the Members Only Events Settings Tab

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.24.6 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.28.3 --cms-ver 7.77 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.24.6
+          version: 5.28.3
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2

--- a/CRM/MembersOnlyEvent/Hook/Tabset/Event.php
+++ b/CRM/MembersOnlyEvent/Hook/Tabset/Event.php
@@ -1,0 +1,61 @@
+<?php
+
+use CRM_MembersOnlyEvent_BAO_MembersOnlyEvent as MembersOnlyEvent;
+
+/**
+ * Class CRM_MembersOnlyEvent_Hook_Event
+ */
+class CRM_MembersOnlyEvent_Hook_Tabset_Event {
+
+  /**
+   * @param $eventID
+   * @param $tabs
+   */
+  public function handle($eventID, &$tabs) {
+    $url = CRM_Utils_System::url(
+      'civicrm/event/manage/membersonlyevent',
+      'reset=1&id=' . $eventID . '&action=update&component=event');
+
+    $tab['membersonlyevent'] = [
+      'title' => ts('Members only event settings'),
+      'link' => $url,
+      'valid' => $this->isTabValid($eventID),
+      'active' => TRUE,
+      'current' => FALSE,
+      'class' => 'ajaxForm',
+    ];
+
+    //Insert this tab into position 4 (after `Online Registration` tab)
+    $tabs = array_merge(
+      array_slice($tabs, 0, 4),
+      $tab,
+      array_slice($tabs, 4)
+    );
+  }
+
+  /**
+   * Checks if the members-only settings tab
+   * should be valid or not. Currently it is valid
+   * only if the event is members-only event and
+   * online registration is enabled.
+   *
+   * @param int $eventID
+   *
+   * @return bool
+   *
+   */
+  private function isTabValid($eventID) {
+    $event = civicrm_api3('Event', 'get', [
+      'sequential' => 1,
+      'return' => array('is_online_registration'),
+      'id' => $eventID,
+    ]);
+
+    $membersOnlyEvent = MembersOnlyEvent::getMembersOnlyEvent($eventID);
+    $isOnlineRegistrationEnabled = !empty($event['values'][0]['is_online_registration']) ? TRUE : FALSE;
+    $isValid = $isOnlineRegistrationEnabled && $membersOnlyEvent ? TRUE : FALSE;
+
+    return $isValid;
+  }
+
+}

--- a/CRM/MembersOnlyEvent/Hook/Tabset/Event.php
+++ b/CRM/MembersOnlyEvent/Hook/Tabset/Event.php
@@ -17,7 +17,7 @@ class CRM_MembersOnlyEvent_Hook_Tabset_Event {
       'reset=1&id=' . $eventID . '&action=update&component=event');
 
     $tab['membersonlyevent'] = [
-      'title' => ts('Members only event settings'),
+      'title' => ts('Members Only Event Settings'),
       'link' => $url,
       'valid' => $this->isTabValid($eventID),
       'active' => TRUE,

--- a/CRM/MembersOnlyEvent/Test/Fabricator/MembershipType.php
+++ b/CRM/MembersOnlyEvent/Test/Fabricator/MembershipType.php
@@ -17,6 +17,10 @@ class CRM_MembersOnlyEvent_Test_Fabricator_MembershipType {
 
     $membershipType = new MembershipType();
 
+    if (empty($params['name'])) {
+      $params['name'] = md5(mt_rand());
+    }
+
     foreach ($params as $property => $value) {
       $membershipType->$property = $value;
     }

--- a/tests/phpunit/CRM/MembersOnlyEvent/Hook/Tabset/EventTest.php
+++ b/tests/phpunit/CRM/MembersOnlyEvent/Hook/Tabset/EventTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use CRM_MembersOnlyEvent_Test_Fabricator_Event as EventFabricator;
+use CRM_MembersOnlyEvent_Test_Fabricator_MembersOnlyEvent as MembersOnlyEventFabricator;
+
+require_once __DIR__ . '/../../../../BaseHeadlessTest.php';
+
+/**
+ * Class CRM_MembersOnlyEvent_Hook_Tabset_EventTest
+ */
+class CRM_MembersOnlyEvent_Hook_Tabset_EventTest extends BaseHeadlessTest {
+
+  /**
+   * Tests valid members only event for tab set hook
+   * when event online registration is enable
+   */
+  public function testValidMembersOnlyEventTabSet() {
+    $event = EventFabricator::fabricate(['is_online_registration' => TRUE]);
+    MembersOnlyEventFabricator::fabricate(['event_id' => $event->id]);
+    $evenTabset = new CRM_MembersOnlyEvent_Hook_Tabset_Event();
+    $tabsets = [];
+    $evenTabset->handle($event->id, $tabsets);
+    $this->assertArrayHasKey('membersonlyevent', $tabsets);
+    $this->assertTrue($tabsets['membersonlyevent']['valid']);
+  }
+
+  /**
+   * Tests invalid members only event for tab set hook
+   * when event online registration is not enabled
+   */
+  public function testInValidMemberOnlyEventTabSet() {
+    $event = EventFabricator::fabricate(['is_online_registration' => FALSE]);
+    $membersOnlyEventTemplate = MembersOnlyEventFabricator::fabricate(['event_id' => $event->id]);
+    $tabsets = [];
+    $evenTabset = new CRM_MembersOnlyEvent_Hook_Tabset_Event();
+    $evenTabset->handle($event->id, $tabsets);
+    $this->assertArrayHasKey('membersonlyevent', $tabsets);
+    $this->assertFalse($tabsets['membersonlyevent']['valid']);
+  }
+
+}


### PR DESCRIPTION
## Overview

This PR is to capitalise the Members only events settings tab title, so it aligns with other event setting tabs. 

This PR also refactors to the tabset hook by implementing an Event Tabset hook class and add unit tests for improving the maintainability of the code. 

## Before
![9b9a7641-87c3-4cb9-bad4-115fe614efa5](https://user-images.githubusercontent.com/208713/103572429-72b5b680-4ec4-11eb-8470-0671ad876d90.png)

## After
![Screenshot from 2021-01-04 19-37-37](https://user-images.githubusercontent.com/208713/103572372-5b76c900-4ec4-11eb-84f9-0bb1b8bae493.png)

