### PR TITLE
PSHEASSN-517: Handle fees block in Event Info page

### DIFF
--- a/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
+++ b/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
@@ -64,7 +64,7 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
 
     if (!empty($priceFieldValues)) {
       $includePriceFieldValues = &$this->addElement('advmultiselect', 'non_member_price_field_values',
-        ts('Select price field to hide from members') . ' ', $priceFieldValues, [
+        ts('Select price fields to be hidden from members') . ' ', $priceFieldValues, [
           'size' => 5,
           'style' => 'width:150px',
           'class' => 'advmultiselect members-only-event-price-field-values',

--- a/CRM/MembersOnlyEvent/Hook/BuildForm/Register.php
+++ b/CRM/MembersOnlyEvent/Hook/BuildForm/Register.php
@@ -32,7 +32,7 @@ class CRM_MembersOnlyEvent_Hook_BuildForm_Register extends BuildFormBase {
   protected function shouldHandle($formName, &$form) {
     if ($formName === CRM_Event_Form_Registration_Register::class
       && $form->getAction() === CRM_Core_Action::ADD
-      && $this->membersOnlyEventAccess->getMembersOnlyEvent()) {
+      && $this->membersOnlyEventAccessService->getMembersOnlyEvent()) {
       return TRUE;
     }
     return FALSE;

--- a/CRM/MembersOnlyEvent/Hook/BuildForm/Register.php
+++ b/CRM/MembersOnlyEvent/Hook/BuildForm/Register.php
@@ -62,7 +62,13 @@ class CRM_MembersOnlyEvent_Hook_BuildForm_Register extends BuildFormBase {
               continue 2;
             }
 
-            $priceFieldValueID = $element->getAttribute('value');
+            if ($isCheckboxElement) {
+              $priceFieldValueID = $element->getAttribute('id');
+            }
+            else {
+              $priceFieldValueID = $element->getAttribute('value');
+            }
+
             $isNonMemberPriceFieldValue = in_array($priceFieldValueID, $nonMemberPriceFieldValueIDs);
 
             if (!$hasMembership && $isNonMemberPriceFieldValue) {

--- a/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
+++ b/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
@@ -3,6 +3,7 @@
 use CRM_MembersOnlyEvent_Hook_PageRun_Base as PageRunBase;
 use CRM_MembersOnlyEvent_BAO_MembersOnlyEvent as MembersOnlyEvent;
 use CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess as MembersOnlyEventAccessService;
+use CRM_MembersOnlyEvent_BAO_MembersOnlyEventPriceFieldValue as MembersOnlyEventPriceFieldValue;
 
 /**
  * Class for Event Info PageRun Hook
@@ -13,6 +14,26 @@ class CRM_MembersOnlyEvent_Hook_PageRun_Register extends PageRunBase {
    * @var \CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess
    */
   private $membersOnlyEventAccessService;
+
+  /**
+   * @var array
+   */
+  private $nonMemberPriceFieldValueIDs;
+
+  /**
+   * @var bool
+   */
+  private $hasMembership;
+
+  /**
+   * @var array
+   */
+  private $feeItems;
+
+  /**
+   * @var int
+   */
+  private $feeBlockIndex;
 
   /**
    * CRM_MembersOnlyEvent_Hook_BuildForm_Register constructor.
@@ -30,7 +51,7 @@ class CRM_MembersOnlyEvent_Hook_PageRun_Register extends PageRunBase {
    * @return bool
    */
   protected function shouldHandle($pageName, &$page) {
-    if ($pageName === CRM_Event_Page_EventInfo::class) {
+    if ($pageName === CRM_Event_Page_EventInfo::class && $this->membersOnlyEventAccessService->getMembersOnlyEvent()) {
       return TRUE;
     }
     return FALSE;
@@ -43,6 +64,139 @@ class CRM_MembersOnlyEvent_Hook_PageRun_Register extends PageRunBase {
    */
   protected function pageRun(&$page) {
     $this->showSessionMessageWhenRegisteringAnotherParticipant();
+    $this->handleFeeBlock();
+  }
+
+  /**
+   * Handles fee block in Event Info page.
+   *
+   * Ensures showing/hiding the right price field values depending on the current
+   * user's membership. Alters the Smarty variable feeBlock because the values are
+   * already proccessed.
+   */
+  private function handleFeeBlock() {
+    $membersOnlyEvent = $this->membersOnlyEventAccessService->getMembersOnlyEvent();
+    $this->nonMemberPriceFieldValueIDs = MembersOnlyEventPriceFieldValue::getNonMemberPriceFieldValueIDs($membersOnlyEvent->id);
+    $this->hasMembership = $this->membersOnlyEventAccessService->hasMembership();
+
+    $smarty = CRM_Core_Smarty::singleton();
+    $this->feeItems = $this->getFeeItems($membersOnlyEvent->event_id);
+
+    // We cannot access the array index in the callback so we will use feeBlockIndex instead.
+    $this->feeBlockIndex = 0;
+    $feeItemsThatNeedToBeRemoved = array_reduce(
+      $smarty->_tpl_vars['feeBlock']['label'],
+      [$this, 'getFeeItemsThatNeedToBeRemoved'],
+      []);
+
+    $this->removeFeeItems($smarty, $feeItemsThatNeedToBeRemoved);
+  }
+
+  /**
+   * Gets fee items that need to be removed.
+   *
+   * - If the fee item is for the price field then do nothing.
+   * - if the fee item is for the price field value then return its index depending
+   *   on the user having a membership.
+   * - if the price field has 'Admin' visiblitiy and the user is anonymous then
+   *   the feeItems will have more values than feeBlock hence we need to increament
+   *   the feeBlockIndex.
+   *
+   * @return array
+   */
+  private function getFeeItemsThatNeedToBeRemoved($feeItemsThatNeedToBeRemoved, $label) {
+    $this->feeBlockIndex++;
+    $priceFieldValueID = NULL;
+    while ($this->feeBlockIndex <= count($this->feeItems)) {
+      $priceField = $this->feeItems[$this->feeBlockIndex] ?? NULL;
+      if (!$priceField || ($priceField && $priceField['isPriceField'])) {
+        return $feeItemsThatNeedToBeRemoved;
+      }
+      if ($priceField['label'] === $label) {
+        $priceFieldValueID = $priceField['id'];
+        break;
+      }
+      else {
+        $this->feeBlockIndex++;
+      }
+    }
+
+    $isNonMemberPriceFieldValue = in_array($priceFieldValueID, $this->nonMemberPriceFieldValueIDs);
+
+    // If the current user is not a member, remove any member price field value
+    if (!$this->hasMembership && !$isNonMemberPriceFieldValue) {
+      $feeItemsThatNeedToBeRemoved[] = $this->feeBlockIndex;
+    }
+
+    // If the current user is a member, remove any non-member price field value
+    if ($this->hasMembership && $isNonMemberPriceFieldValue) {
+      $feeItemsThatNeedToBeRemoved[] = $this->feeBlockIndex;
+    }
+
+    return $feeItemsThatNeedToBeRemoved;
+  }
+
+  /**
+   * @return array
+   */
+  private function getFeeItems($EventId) {
+    $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_event', $EventId, NULL);
+    // Get only the values of the active price fields and ordered by weight because this
+    // is how CiviCRM fetch them
+    // see https://github.com/civicrm/civicrm-core/blob/5.35.1/CRM/Event/Page/EventInfo.php#L97
+    // and https://github.com/civicrm/civicrm-core/blob/5.35.1/CRM/Price/BAO/PriceSet.php#L422
+    $priceFields = civicrm_api3('PriceField', 'get', [
+      'sequential' => 1,
+      'price_set_id' => $priceSetId,
+      'is_active' => 1,
+      'return' => ['id', 'label'],
+      'options' => ['sort' => 'weight asc'],
+      'api.PriceFieldValue.get' => [
+        'is_active' => 1,
+        'return' => ['id', 'label'],
+        'options' => ['sort' => 'weight, label'],
+      ],
+    ])['values'];
+
+    // Add an empty value to start the array index from 1
+    $feeItems = [''];
+    foreach ($priceFields as $priceField) {
+      $feeItems[] = [
+        'id' => $priceField['id'],
+        'label' => $priceField['label'],
+        'isPriceField' => TRUE,
+      ];
+      foreach ($priceField['api.PriceFieldValue.get']['values'] as $priceFieldValue) {
+        $feeItems[] = [
+          'id' => $priceFieldValue['id'],
+          'label' => $priceFieldValue['label'],
+          'isPriceField' => FALSE,
+        ];
+      }
+    }
+
+    return $feeItems;
+  }
+
+  /**
+   * Removes fee items from feeBlock
+   *
+   * @param \CRM_Core_Smarty $smarty
+   * @param array $feeItemIDs
+   */
+  private function removeFeeItems(&$smarty, $feeItemIDs) {
+    foreach ($feeItemIDs as $key) {
+      unset($smarty->_tpl_vars['feeBlock']['value'][$key]);
+      unset($smarty->_tpl_vars['feeBlock']['label'][$key]);
+      unset($smarty->_tpl_vars['feeBlock']['lClass'][$key]);
+      unset($smarty->_tpl_vars['feeBlock']['isDisplayAmount'][$key]);
+    }
+
+    // Change array key to start from 1 instead of 0
+    foreach (['value', 'label', 'lClass', 'isDisplayAmount'] as $key) {
+      array_unshift($smarty->_tpl_vars['feeBlock'][$key], "");
+      unset($smarty->_tpl_vars['feeBlock'][$key][0]);
+    }
   }
 
   /**
@@ -51,10 +205,6 @@ class CRM_MembersOnlyEvent_Hook_PageRun_Register extends PageRunBase {
    */
   private function showSessionMessageWhenRegisteringAnotherParticipant() {
     $isEventForMembersOnly = $this->membersOnlyEventAccessService->getMembersOnlyEvent();
-
-    if (!$isEventForMembersOnly) {
-      return;
-    }
 
     $session = CRM_Core_Session::singleton();
     $statusMessages = $session->get('status');

--- a/CRM/MembersOnlyEvent/Hook/Tabset/Event.php
+++ b/CRM/MembersOnlyEvent/Hook/Tabset/Event.php
@@ -35,7 +35,7 @@ class CRM_MembersOnlyEvent_Hook_Tabset_Event {
   private function shouldHandle($tabsetName, &$tabs, $context) {
     $canEditAllEvents = CRM_Core_Permission::check(['edit all events']);
     $isManageEventTabset = ($tabsetName === 'civicrm/event/manage');
-    if (!empty($context['event_id'] && $isManageEventTabset && $canEditAllEvents)) {
+    if (!empty($context['event_id']) && $isManageEventTabset && $canEditAllEvents) {
       return TRUE;
     }
     return FALSE;


### PR DESCRIPTION
## Overview
This PR is to alter the fee block in the Event Info page to show the right price field values depending on the current user's membership.

Created price set with two price field and each one has two options then configured members only event.
![Screenshot from 2021-04-16 17-41-16](https://user-images.githubusercontent.com/74309109/115041467-33433100-9edb-11eb-8aa9-0dbd2d264ce3.png)
![Screenshot from 2021-04-16 17-41-59](https://user-images.githubusercontent.com/74309109/115041496-3d652f80-9edb-11eb-98e4-93157b062d92.png)


## Before - Event Info
Event Info page will show all fee items.
![Screenshot from 2021-04-16 17-37-47](https://user-images.githubusercontent.com/74309109/115041606-5d94ee80-9edb-11eb-8a4e-fa16c9a847bf.png)

## After - Event Info
Event Info page will show fee items depending on the user's membership - below you will see non member price field values.
![Screenshot from 2021-04-16 17-40-38](https://user-images.githubusercontent.com/74309109/115041559-5077ff80-9edb-11eb-868a-b9043bf252f1.png)

## Before - Event Registration
There is no checkbox options.
![Screenshot from 2021-04-16 17-39-24](https://user-images.githubusercontent.com/74309109/115041610-5ff74880-9edb-11eb-9f1f-e41e31c6f672.png)

## After  - Event Registration
Checkbox options are visible.
![Screenshot from 2021-04-16 17-40-17](https://user-images.githubusercontent.com/74309109/115041568-52da5980-9edb-11eb-9284-3d1978537096.png)


## Technical Details
I used the `hook_civicrm_pageRun` hook to alter the Event Info page, but the values are already proccessed and sent to `Smarty` template.

Below you can see `$_template->_tpl_vars['feeBlock']` value:
```php
array(4) {
  ["value"]=>
  array(6) {
    [1]=>
    string(0) ""
    [2]=>
    string(12) "50.000000000"
    [3]=>
    string(12) "20.000000000"
    [4]=>
    string(0) ""
    [5]=>
    string(12) "50.000000000"
    [6]=>
    string(12) "20.000000000"
  }
  ["label"]=>
  array(6) {
    [1]=>
    string(26) "Event Fee - CheckBox Group"
    [2]=>
    string(23) "Non-member fee CheckBox"
    [3]=>
    string(19) "Member fee CheckBox"
    [4]=>
    string(23) "Event Fee - Radio Group"
    [5]=>
    string(20) "Non-member fee Radio"
    [6]=>
    string(16) "Member fee Radio"
  }
  ["lClass"]=>
  array(6) {
    [1]=>
    string(28) "price_set_option_group-label"
    [2]=>
    string(22) "price_set_option-label"
    [3]=>
    string(22) "price_set_option-label"
    [4]=>
    string(28) "price_set_option_group-label"
    [5]=>
    string(22) "price_set_option-label"
    [6]=>
    string(22) "price_set_option-label"
  }
  ["isDisplayAmount"]=>
  array(6) {
    [1]=>
    string(1) "1"
    [2]=>
    string(1) "1"
    [3]=>
    string(1) "1"
    [4]=>
    string(1) "1"
    [5]=>
    string(1) "1"
    [6]=>
    string(1) "1"
  }
}
```
As you can see the fee items include both price fields and price field values and it is bad idea to guess the ID from the label. Instead, the method `getFeeItems` will return fee items with their `ID` then altered `$_template->_tpl_vars['feeBlock']` to hide price field values depending on user's membership.

## Comments
This PR contains these small fixes/updates  : 
- Fixed undefined property in BuildForm hook
- Fixed a typo in the empty condition.
- Fixed the missing checkbox options issue.
- Updated multi-select label