### PR TITLE
WHF-213: Expose MembersOnlyEventAccess.get API to check for groups-only events

### DIFF
--- a/CRM/MembersOnlyEvent/BAO/EventGroup.php
+++ b/CRM/MembersOnlyEvent/BAO/EventGroup.php
@@ -155,4 +155,23 @@ class CRM_MembersOnlyEvent_BAO_EventGroup extends CRM_MembersOnlyEvent_DAO_Event
     return self::$contactGroupIDs;
   }
 
+  /**
+   * Gets the event-groups event data given the event IDs
+   *
+   * @param $membersOnlyEventIDs
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getEventGroups($membersOnlyEventIDs) {
+    $result = civicrm_api3('EventGroup', 'get', [
+      'sequential' => 1,
+      'members_only_event_id' => ['IN' => $membersOnlyEventIDs],
+      'return' => ['members_only_event_id', 'group_id'],
+      'options' => ['limit' => 0],
+    ]);
+
+    return $result['values'] ?? [];
+  }
+
 }

--- a/CRM/MembersOnlyEvent/BAO/MembersOnlyEvent.php
+++ b/CRM/MembersOnlyEvent/BAO/MembersOnlyEvent.php
@@ -60,4 +60,24 @@ class CRM_MembersOnlyEvent_BAO_MembersOnlyEvent extends CRM_MembersOnlyEvent_DAO
     return FALSE;
   }
 
+  /**
+   * Gets the members-only events given the event IDs
+   *
+   * @param $eventIDs
+   *
+   * @return array
+   * @throws \CiviCRM_API3_Exception
+   */
+  public static function getMembersOnlyEvents($eventIDs) {
+    $result = civicrm_api3('MembersOnlyEvent', 'get', [
+      'sequential' => 1,
+      'is_groups_only' => 1,
+      'event_id' => ['IN' => $eventIDs],
+      'return' => ['id', 'event_id'],
+      'options' => ['limit' => 0],
+    ]);
+
+    return $result['values'] ?? [];
+  }
+
 }

--- a/CRM/MembersOnlyEvent/Utils/Array.php
+++ b/CRM/MembersOnlyEvent/Utils/Array.php
@@ -1,0 +1,22 @@
+<?php
+
+class CRM_MembersOnlyEvent_Utils_Array {
+
+  /**
+   * Creates an array composed of keys generated from the result of running
+   * each element of $items thru the foreach and the value is the corresponding
+   * value of each key.
+   *
+   * @param array $items
+   * @param string $key
+   */
+  public static function keyBy(array $items, string $key) {
+    $result = [];
+    foreach ($items as $item) {
+      $result[$item[$key]] = $item;
+    }
+
+    return $result;
+  }
+
+}

--- a/api/v3/MembersOnlyEventAccess.php
+++ b/api/v3/MembersOnlyEventAccess.php
@@ -1,0 +1,30 @@
+<?php
+
+use CRM_MembersOnlyEvent_ExtensionUtil as E;
+use CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess as MembersOnlyEventAccessService;
+
+/**
+ * MembersOnlyEventAccess.get API.
+ *
+ * @param array $params
+ *   event_id
+ *
+ * @return array
+ *   API result descriptor
+ *
+ * @throws \CRM_Core_Exception
+ */
+function civicrm_api3_members_only_event_access_get($params) {
+  $eventIDs = [];
+  if (isset($params['event_id']) && is_int($params['event_id'])) {
+    $eventIDs = [$params['event_id']];
+  }
+
+  if (isset($params['event_id']) && is_array($params['event_id'])) {
+    $eventIDs = $params['event_id']['IN'];
+  }
+
+  $eventAccesses = MembersOnlyEventAccessService::getEventAccessDetails($eventIDs);
+
+  return civicrm_api3_create_success($eventAccesses, $params);
+}


### PR DESCRIPTION
## Overview
This PR is to expose `MembersOnlyEventAccess.get` API to gets event access details for a given event ids, this is useful to check for groups-only events.

## Technical Details
The API returns event access details as follows: 
```php
[
  'event_id' => 1,
  'is_groups_only_event' => TRUE,
  'allowed_groups' => [1, 2],
  'does_user_belongs_to_any_allowed_group' => TRUE,
  'allowed_groups_which_user_belongs_to' => [1],
]