### PR TITLE
WHF-224: Fix a typo

### DIFF
--- a/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
+++ b/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
@@ -219,7 +219,7 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
         'event_id' => $eventID,
         'is_groups_only_event' => !empty($groupsKeyedByEventID[$eventID]),
         'allowed_groups' => $groups,
-        'does_user_belongs_to_any_allowed_group' => !empty($allowedGroupsWhichUserBelongsTo),
+        'is_user_in_any_allowed_group' => !empty($allowedGroupsWhichUserBelongsTo),
         'allowed_groups_which_user_belongs_to' => $allowedGroupsWhichUserBelongsTo,
       ];
     }


### PR DESCRIPTION
## Overview
This PR is to address the the typo created in the previous https://github.com/compucorp/uk.co.compucorp.membersonlyevent/pull/15 PR. @erawat suggested a better name, so I thought it is better to use it instead.

```diff
[
- 'does_user_belongs_to_any_allowed_group' => !empty($allowedGroupsWhichUserBelongsTo),                                                                    
+ 'is_user_in_any_allowed_group' => !empty($allowedGroupsWhichUserBelongsTo),
]
```
