### PR TITLE
WHF-225: Update members only event tab

### DIFF
--- a/js/CRM/Form/MembersOnlyEventTab.js
+++ b/js/CRM/Form/MembersOnlyEventTab.js
@@ -5,8 +5,7 @@ jQuery(document).ready(function(){
   var LINK_TYPE_CONTRIBUTION_PAGE = '0';
   var LINK_TYPE_URL = '1';
 
-  var membersOnlyEventCheckbox= jQuery("#is_members_only_event");
-  var groupsOnlyEventCheckbox= jQuery("#is_groups_only_event");
+  var eventAccessTypeField = jQuery("#event-access-type");
   var membersOnlyEventSection = jQuery("#members-only-event-section");
   var allowedMembershipTypesField = jQuery("#allowed-membership-types-field");
   var allowedGroupsField = jQuery("#allowed-groups-field");
@@ -35,31 +34,16 @@ jQuery(document).ready(function(){
   }
 
   /**
-   * Gets is_members_only_event value
-   */
-  function getIsMembersOnlyEventValue() {
-    return membersOnlyEventCheckbox.is(':checked') && !groupsOnlyEventCheckbox.is(':checked');
-  }
-
-  /**
-   * Gets is_groups_only_event value
-   */
-  function getIsGroupsOnlyEventValue() {
-    return !membersOnlyEventCheckbox.is(':checked') && groupsOnlyEventCheckbox.is(':checked');
-  }
-
-  /**
    * Sets the fields event listeners
    */
   function setFieldListeners() {
-    membersOnlyEventCheckbox.click(function(){
-      groupsOnlyEventCheckbox.prop('checked', false);
-      toggleTabFields();
-    });
+    eventAccessTypeField.change(toggleTabFields);
 
-    groupsOnlyEventCheckbox.click(function(){
-      membersOnlyEventCheckbox.prop('checked', false);
-      toggleTabFields();
+    eventAccessTypeField.click(function(e){
+      // Checks if target is the crm-clear-link.
+      if (jQuery(e.target).hasClass('crm-clear-link') || jQuery(e.target).hasClass('fa-times')) {
+        membersOnlyEventSection.hide();
+      }
     });
 
     purchaseMembershipButtonField.click(togglePurchaseButtonFields);
@@ -75,21 +59,14 @@ jQuery(document).ready(function(){
    * value.
    */
   function toggleTabFields() {
-    let isMembersOnlyEventValue = getIsMembersOnlyEventValue();
-    let isGroupsOnlyEventValue = getIsGroupsOnlyEventValue();
-
-    if (isMembersOnlyEventValue || isGroupsOnlyEventValue){
-      if (isMembersOnlyEventValue) {
-        allowedMembershipTypesField.show();
-        allowedGroupsField.hide();
-      }
-
-      if (isGroupsOnlyEventValue) {
-        allowedMembershipTypesField.hide();
-        allowedGroupsField.show();
-      }
-
-      membersOnlyEventFields.show();
+    if (eventAccessTypeField.find(':checked').val() === 'members_only') {
+      membersOnlyEventSection.show();
+      allowedMembershipTypesField.show();
+      allowedGroupsField.hide();
+    } else if (eventAccessTypeField.find(':checked').val() === 'groups_only') {
+      membersOnlyEventSection.show();
+      allowedMembershipTypesField.hide();
+      allowedGroupsField.show();
     } else {
       membersOnlyEventSection.hide();
     }

--- a/js/CRM/Form/MembersOnlyEventTab.js
+++ b/js/CRM/Form/MembersOnlyEventTab.js
@@ -7,10 +7,11 @@ jQuery(document).ready(function(){
 
   var membersOnlyEventCheckbox= jQuery("#is_members_only_event");
   var groupsOnlyEventCheckbox= jQuery("#is_groups_only_event");
-  var membersOnlyEventFields = jQuery("#members-only-event-fields");
+  var membersOnlyEventSection = jQuery("#members-only-event-section");
   var allowedMembershipTypesField = jQuery("#allowed-membership-types-field");
   var allowedGroupsField = jQuery("#allowed-groups-field");
 
+  var purchaseMembershipButtonField = jQuery("#purchase-membership-button");
   var purchaseButtonDisabledSection = jQuery("#purchase-button-disabled-section");
   var purchaseButtonEnabledSection = jQuery("#purchase-button-enabled-section");
 
@@ -27,8 +28,7 @@ jQuery(document).ready(function(){
   function setInitialFieldValues() {
     toggleTabFields();
 
-    var purchaseMembershipButtonEnabled = jQuery("input[name='purchase_membership_button']:checked").val();
-    togglePurchaseButtonFields(purchaseMembershipButtonEnabled);
+    togglePurchaseButtonFields();
 
     var purchaseLinkType = jQuery("input[name='purchase_membership_link_type']:checked").val();
     toggleLinkTypeFields(purchaseLinkType);
@@ -62,9 +62,7 @@ jQuery(document).ready(function(){
       toggleTabFields();
     });
 
-    jQuery("input[name='purchase_membership_button']").click(function(){
-      togglePurchaseButtonFields(jQuery(this).val());
-    });
+    purchaseMembershipButtonField.click(togglePurchaseButtonFields);
 
     jQuery("input[name='purchase_membership_link_type']").click(function(){
       toggleLinkTypeFields(jQuery(this).val());
@@ -93,21 +91,20 @@ jQuery(document).ready(function(){
 
       membersOnlyEventFields.show();
     } else {
-      membersOnlyEventFields.hide();
+      membersOnlyEventSection.hide();
     }
   }
 
   /**
    * Shows/Hides the related purchase membership
    * button fields.
-   * If Yes is selected then allow the user to set
+   * If the selectedOption was Yes then allow the user to set
    * button label and the link.
-   * If No is selected then show only the
+   * If the selectedOption was selected then show only the
    * notice message textarea.
-   *
-   * @param selectedOption
    */
-  function togglePurchaseButtonFields(selectedOption) {
+  function togglePurchaseButtonFields() {
+    var selectedOption = purchaseMembershipButtonField.find(':checked').val()
     switch (selectedOption) {
       case NO_SELECTED:
         purchaseButtonDisabledSection.show();

--- a/js/CRM/Form/MembersOnlyEventTab.js
+++ b/js/CRM/Form/MembersOnlyEventTab.js
@@ -63,10 +63,17 @@ jQuery(document).ready(function(){
       membersOnlyEventSection.show();
       allowedMembershipTypesField.show();
       allowedGroupsField.hide();
+      purchaseMembershipButtonField.show();
     } else if (eventAccessTypeField.find(':checked').val() === 'groups_only') {
       membersOnlyEventSection.show();
       allowedMembershipTypesField.hide();
       allowedGroupsField.show();
+
+      // Only shows allowed_groups and notice_for_access_denied fields if the
+      // groups_only option was chosen.
+      purchaseMembershipButtonField.find('[value=' + NO_SELECTED + ']').prop('checked', true)
+      purchaseMembershipButtonField.click();
+      purchaseMembershipButtonField.hide();
     } else {
       membersOnlyEventSection.hide();
     }

--- a/templates/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.tpl
+++ b/templates/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.tpl
@@ -4,20 +4,10 @@
     {include file="CRM/common/formButtons.tpl" location="top"}
   </div>
 
-  <div class="crm-section">
+  <div class="crm-section" id="event-access-type">
     <div class="label"></div>
     <div class="content">
-      {$form.is_members_only_event.html}
-      {$form.is_members_only_event.label}
-    </div>
-    <div class="clear"></div>
-  </div>
-
-  <div class="crm-section">
-    <div class="label"></div>
-    <div class="content">
-      {$form.is_groups_only_event.html}
-      {$form.is_groups_only_event.label}
+      {$form.event_access_type.html}
     </div>
     <div class="clear"></div>
   </div>

--- a/templates/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.tpl
+++ b/templates/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.tpl
@@ -22,7 +22,7 @@
     <div class="clear"></div>
   </div>
 
-  <div id="members-only-event-fields">
+  <div id="members-only-event-section">
     <div class="crm-section" id="allowed-membership-types-field">
       <div class="label">{$form.allowed_membership_types.label} {help id="allowed-membership-types" file="CRM/MembersOnlyEvent/Form/MembersOnlyEventTab"}</div>
       <div class="content">{$form.allowed_membership_types.html}</div>
@@ -35,7 +35,7 @@
       <div class="clear"></div>
     </div>
 
-    <div class="crm-section">
+    <div class="crm-section" id="purchase-membership-button">
       <div class="label">{$form.purchase_membership_button.label}</div>
       <div class="content">{$form.purchase_membership_button.html}</div>
       <div class="clear"></div>

--- a/tests/phpunit/CRM/MembersOnlyEvent/Form/MembersOnlyEventTabTest.php
+++ b/tests/phpunit/CRM/MembersOnlyEvent/Form/MembersOnlyEventTabTest.php
@@ -27,7 +27,7 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTabTest extends BaseHeadlessTest
     $eventID = $this->mockEvent();
     $this->membersOnlyEventTab->_id = $eventID;
     $this->membersOnlyEventTab->buildQuickForm();
-    $isGroupsOnlyEventElement = $this->membersOnlyEventTab->getElement('is_members_only_event');
+    $isGroupsOnlyEventElement = $this->membersOnlyEventTab->getElement('event_access_type');
     $this->assertTrue(is_object($isGroupsOnlyEventElement));
   }
 


### PR DESCRIPTION
## Overview
This PR updates the "Members Only Event" tab layout.

## Before
- The input type for "Only allow members to register for this event?" is checkbox.
- The input type for "Only allow contacts in groups to register for this event?" is checkbox.
- The "Purchase Membership Button" related fields are shown when selecting "Only allow contacts in groups to register for this event?" 
![Peek 2021-05-24 14-48](https://user-images.githubusercontent.com/74309109/119343502-35996780-bc9f-11eb-9d5e-76a8df28b995.gif)

## After
- The input type for "Only allow members to register for this event?" is radio button.
- The input type for "Only allow contacts in groups to register for this event?" is radio button.
- The "Purchase Membership Button" related fields are hidden when selecting "Only allow contacts in groups to register for this event?" 

![Peek 2021-05-24 14-46](https://user-images.githubusercontent.com/74309109/119343510-38945800-bc9f-11eb-9edb-50602493adcb.gif)

## Technical Details
First, I refactored the file `MembersOnlyEventTab.js`. Second, used the radio buttons instead of checkboxes for members only event tab. Third, the "Purchase Membership Button" related fields should be hidden if the the option "Only allow contacts in groups to register for this event?" was selected.
