### PR TITLE
WHF-226: Allow "any" option for members only event

### DIFF
--- a/CRM/MembersOnlyEvent/BAO/EventMembershipType.php
+++ b/CRM/MembersOnlyEvent/BAO/EventMembershipType.php
@@ -100,17 +100,16 @@ class CRM_MembersOnlyEvent_BAO_EventMembershipType extends CRM_MembersOnlyEvent_
    *   List of contact Memberships or empty array if nothing found
    */
   public static function getContactActiveAllowedMemberships($membersOnlyEventID, $contactID) {
-    $allowedMembershipTypes = self::getAllowedMembershipTypeIDs($membersOnlyEventID);
-    if (empty($allowedMembershipTypes)) {
-      return [];
-    }
-
     $params = [
       'sequential' => 1,
       'contact_id' => $contactID,
       'active_only' => 1,
-      'membership_type_id' => ['IN' => $allowedMembershipTypes],
     ];
+
+    $allowedMembershipTypes = self::getAllowedMembershipTypeIDs($membersOnlyEventID);
+    if (!empty($allowedMembershipTypes)) {
+      $params['membership_type_id'] = ['IN' => $allowedMembershipTypes];
+    }
 
     $contactActiveMemberships = civicrm_api3('Membership', 'get', $params);
 

--- a/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
+++ b/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
@@ -84,7 +84,6 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
       [
         'entity' => 'Group',
         'multiple' => TRUE,
-        'placeholder' => ts('- any -'),
         'select' => ['minimumInputLength' => 0],
       ]
     );
@@ -143,11 +142,14 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
   public function formRules($values) {
     $errors = [];
 
-    // Skip validation if the event is not members-only or groups-only
-    $isMembersOnlyEvent = $values['event_access_type'] === 'members_only';
-    $isGroupsOnlyEvent = $values['event_access_type'] === 'groups_only';
-    if ($isMembersOnlyEvent || $isGroupsOnlyEvent) {
+    // Skip validation if the event is not members-only or not groups-only
+    if (empty($values['event_access_type'])) {
       return $errors;
+    }
+
+    $isGroupsOnlyEvent = $values['event_access_type'] === 'groups_only';
+    if ($isGroupsOnlyEvent) {
+      $this->validateForEmptyAllowedGroups($values, $errors);
     }
 
     switch ($values['purchase_membership_button']) {
@@ -161,6 +163,18 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
     }
 
     return $errors ?: TRUE;
+  }
+
+  /**
+   * Validates form fields when allowed groups field is empty.
+   *
+   * @param array $values
+   * @param array $errors
+   */
+  private function validateForEmptyAllowedGroups(&$values, &$errors) {
+    if (empty($values['allowed_groups'])) {
+      $errors['allowed_groups'] = ts('Please select at least one group');
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR restores the old behavior of the "any" option for "Allowed Membership Types" select input.

![Screenshot from 2021-05-24 15-23-18](https://user-images.githubusercontent.com/74309109/119347291-00434880-bca4-11eb-88a5-0a82e9eac352.png)

## Before
The user cannot register the event if the admin left the "Allowed Membership Types" value empty which has the placeholder "any".

## After
The user can register the event if the admin left the "Allowed Membership Types" value empty which has the placeholder "any".


## Technical Details
This commit  [78f7d4](https://github.com/compucorp/uk.co.compucorp.membersonlyevent/commit/78f7d452ba4a5fe05190fd6c10f2e4da4a173c66) with message "PSHEASSN-517: Fix edge case when there are no allowed memberships" was fixing what I though is a bug, but it turns out it was a feature.
 
The first commit allows the user with any active membership to register the event if the admin chose "any" for the allowed membership types field.


## Comments
This is not the case for groups-only event and the admin has to select one group at least. The second commit adds validation for that.