### PR TITLE
WHF-227: Check for smart groups

### DIFF
--- a/CRM/MembersOnlyEvent/BAO/EventGroup.php
+++ b/CRM/MembersOnlyEvent/BAO/EventGroup.php
@@ -5,13 +5,6 @@ use CRM_MembersOnlyEvent_ExtensionUtil as E;
 class CRM_MembersOnlyEvent_BAO_EventGroup extends CRM_MembersOnlyEvent_DAO_EventGroup {
 
   /**
-   * Static instance to hold the contact's group IDs.
-   *
-   * @var array
-   */
-  private static $contactGroupIDs = NULL;
-
-  /**
    * Stores the allowed groups for specific
    * members-only event
    *
@@ -125,27 +118,23 @@ class CRM_MembersOnlyEvent_BAO_EventGroup extends CRM_MembersOnlyEvent_DAO_Event
    *   List of contact groups or empty array if nothing found
    */
   public static function getContactGroupIDs($contactID) {
-    if (self::$contactGroupIDs !== NULL) {
-      return self::$contactGroupIDs;
-    }
-
-    self::$contactGroupIDs = array_merge(
+    $contactGroupIDs = array_merge(
       self::getContactNormalGroupIds($contactID),
       self::getContactSmartGroupIds($contactID)
     );
 
-    return self::$contactGroupIDs;
+    return $contactGroupIDs;
   }
 
   /**
-   * Gets the normal groups for the specified contact.
+   * Gets The normal (not smart) groups that the contact is part of.
    *
    * @param int $contactID
    *
    * @return array
    *   List of group ids or empty array if nothing found
    */
-  public static function getContactNormalGroupIds($contactID) {
+  private static function getContactNormalGroupIds($contactID) {
     $params = [
       'sequential' => 1,
       'contact_id' => (int) $contactID,
@@ -167,15 +156,14 @@ class CRM_MembersOnlyEvent_BAO_EventGroup extends CRM_MembersOnlyEvent_DAO_Event
   }
 
   /**
-   * Gets the smarty groups for the specified contact.
+   * Gets the smart groups that the contact is part of.
    *
    * @param int $contactID
    *
    * @return array
    *   List of group ids or empty array if nothing found
    */
-  public static function getContactSmartGroupIds($contactID) {
-    // Gets the smart group ids that the contact belongs to.
+  private static function getContactSmartGroupIds($contactID) {
     $query = "SELECT group_id FROM `civicrm_group_contact_cache` WHERE contact_id=%1";
     $queryParams = [
       1 => [(int) $contactID, 'Positive'],
@@ -191,7 +179,7 @@ class CRM_MembersOnlyEvent_BAO_EventGroup extends CRM_MembersOnlyEvent_DAO_Event
   }
 
   /**
-   * Gets the event-groups event data given the event IDs
+   * Gets the event-groups event data given the membersOnlyEvent IDs
    *
    * @param $membersOnlyEventIDs
    *

--- a/CRM/MembersOnlyEvent/Test/Fabricator/Group.php
+++ b/CRM/MembersOnlyEvent/Test/Fabricator/Group.php
@@ -19,6 +19,7 @@ class CRM_MembersOnlyEvent_Test_Fabricator_Group {
 
     if (empty($params['name'])) {
       $params['name'] = md5(mt_rand());
+      $params['title'] = $params['name'];
     }
 
     foreach ($params as $property => $value) {

--- a/CRM/MembersOnlyEvent/Test/Fabricator/SmartGroup.php
+++ b/CRM/MembersOnlyEvent/Test/Fabricator/SmartGroup.php
@@ -1,0 +1,46 @@
+<?php
+
+use CRM_Contact_BAO_Group as Group;
+
+class CRM_MembersOnlyEvent_Test_Fabricator_SmartGroup {
+
+  /**
+   * Fabricates a group.
+   *
+   * @param array $params
+   *
+   * @return \CRM_Contact_BAO_SmartGroup
+   */
+  public static function fabricate($params = []) {
+    $params = array_merge(static::getDefaultParams(), $params);
+
+    if (empty($params['name'])) {
+      $params['name'] = md5(mt_rand());
+      $params['title'] = $params['name'];
+    }
+
+    // CiviCRM uses this methods in GroupContactCache tests to create a smart
+    // group in the file
+    // tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php.
+    $group = Group::createSmartGroup($params);
+
+    return $group;
+  }
+
+  private static function getDefaultParams() {
+    return [
+      'title' => 'SmartGroup A',
+      'description' => 'SmartGroup A description',
+      'source' => 'Test',
+      'is_active' => '1',
+      'visibility' => 'User and User Admin Only',
+      'group_type' => 1,
+      'is_hidden' => 0,
+      'is_reserved' => 0,
+      'frontend_title' => 'SmartGroup A, public name',
+      'frontend_description' => 'SmartGroup A, public description',
+      'formValues' => ['sort_name' => 'Doe'],
+    ];
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR adds support for smart groups.

## Before
The user cannot register the event if he belongs to an allowed smart group.

## After
The user can register the event if he belongs to an allowed smart group.

## Technical Details
I used GroupContact API to fetch the groups that the current logged user belongs to, but this will not work with smart groups.

This PR adds support for smart groups by querying the table `civicrm_group_contact_cache`, I chose the raw query because there is no official API for that.

## Other Comments:
I removed the `CRM_MembersOnlyEvent_BAO_EventGroup::$contactGroupIDs` attribute because of failing tests and there is no point in using it as a cache if the method gets accessed only once during the request.