### PR TITLE
WHF-229: Check for members only event registration permission

### DIFF
--- a/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
+++ b/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
@@ -65,7 +65,17 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
       return FALSE;
     }
 
-    return $this->membersOnlyEvent->is_groups_only ? !empty($this->contactAllowedGroups) : !empty($this->contactActiveAllowedMemberships);
+    if (empty($this->membersOnlyEvent->is_groups_only) && CRM_Core_Permission::check('members only event registration')) {
+      // Any user with 'members only event registration' permission
+      // can access any members-only event.
+      return TRUE;
+    }
+
+    if (empty($this->membersOnlyEvent->is_groups_only)) {
+      return !empty($this->contactActiveAllowedMemberships);
+    }
+
+    return !empty($this->contactAllowedGroups);
   }
 
   /**

--- a/tests/phpunit/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccessTest.php
+++ b/tests/phpunit/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccessTest.php
@@ -90,36 +90,6 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccessTest extends BaseHeadle
   }
 
   /**
-   * Tests redirectUsersWithoutEventAccess().
-   */
-  public function testRedirectUsersWithoutEventAccess() {
-    $event = EventFabricator::fabricate();
-    $membersOnlyEventAccessService = new MembersOnlyEventAccessService($event->id);
-
-    $this->expectException(CRM_Core_Exception_PrematureExitException::class);
-    $membersOnlyEventAccessService->redirectUsersWithoutEventAccess();
-  }
-
-  /**
-   * Tests redirectUsersWithoutEventAccess().
-   */
-  public function testRedirectUsersWithoutEventAccessForLoggedUserWithoutValidMembership() {
-    $this->createLoggedInUser();
-
-    $membersOnlyEvent = MembersOnlyEventFabricator::fabricate();
-    $config = CRM_Core_Config::singleton();
-    $tmpGlobals = [];
-    $tmpGlobals['_GET'][$config->userFrameworkURLVar] = 'civicrm/event/register';
-    CRM_Utils_GlobalStack::singleton()->push($tmpGlobals);
-
-    $membersOnlyEventAccessService = new MembersOnlyEventAccessService($membersOnlyEvent->event_id);
-
-    $this->expectException(CRM_Core_Exception_PrematureExitException::class);
-    $membersOnlyEventAccessService->redirectUsersWithoutEventAccess();
-    CRM_Utils_GlobalStack::singleton()->pop();
-  }
-
-  /**
    * Tests hasMembership for logged user with valid membership
    */
   public function testLoggedUserWithValidMembership() {


### PR DESCRIPTION
## Overview
This PR restores the old behavior that allows any user with the 'members only event registration' permission to access any members-only event.

## Before
The user with the 'members only event registration' permission cannot register the members-only event.

## After
The user with the 'members only event registration' permission can register the members-only event.

## Technical Details
This check has been deleted during the [bf69d3](https://github.com/compucorp/uk.co.compucorp.membersonlyevent/commit/bf69d37cfe1394b23af6d5c944efabd87b67f95c) commit.
