### PR TITLE
WHF-207: Check if the IN's value is not empty

### DIFF
--- a/CRM/MembersOnlyEvent/BAO/EventGroup.php
+++ b/CRM/MembersOnlyEvent/BAO/EventGroup.php
@@ -187,6 +187,10 @@ class CRM_MembersOnlyEvent_BAO_EventGroup extends CRM_MembersOnlyEvent_DAO_Event
    * @throws \CiviCRM_API3_Exception
    */
   public static function getEventGroups($membersOnlyEventIDs) {
+    if (empty($membersOnlyEventIDs)) {
+      return [];
+    }
+
     $result = civicrm_api3('EventGroup', 'get', [
       'sequential' => 1,
       'members_only_event_id' => ['IN' => $membersOnlyEventIDs],

--- a/CRM/MembersOnlyEvent/BAO/MembersOnlyEvent.php
+++ b/CRM/MembersOnlyEvent/BAO/MembersOnlyEvent.php
@@ -69,6 +69,10 @@ class CRM_MembersOnlyEvent_BAO_MembersOnlyEvent extends CRM_MembersOnlyEvent_DAO
    * @throws \CiviCRM_API3_Exception
    */
   public static function getMembersOnlyEvents($eventIDs) {
+    if (empty($eventIDs)) {
+      return [];
+    }
+
     $result = civicrm_api3('MembersOnlyEvent', 'get', [
       'sequential' => 1,
       'is_groups_only' => 1,


### PR DESCRIPTION
## Overview
CiviCRM api v3 throws the CiviCRM_API3_Exception with the message "invalid criteria for IN" if the "IN" parameter was an empty array.

## Before
CiviCRM throws the following exception if we called the methods `EventGroup::getEventGroups` and `MembersOnlyEvent::getMembersOnlyEvents` with empty arrays
```js
array(6) {
  ["%type"]=>
  string(22) "CiviCRM_API3_Exception"
  ["!message"]=>
  string(23) "invalid criteria for IN"
  ["%function"]=>
  string(14) "civicrm_api3()"
  ["%file"]=>
  string(105) "[FILTERED]/contrib/civicrm/api/api.php"
  ["%line"]=>
  int(133)
  ["severity_level"]=>
  int(3)
}
```

## After
Calling the methods `EventGroup::getEventGroups` and `MembersOnlyEvent::getMembersOnlyEvents` with empty arrays will return an empty array without any error.

