### PR TITLE
WHF-245: Return notice_for_access_denied with MembersOnlyEventAccess.get API

### DIFF
--- a/CRM/MembersOnlyEvent/BAO/MembersOnlyEvent.php
+++ b/CRM/MembersOnlyEvent/BAO/MembersOnlyEvent.php
@@ -77,7 +77,7 @@ class CRM_MembersOnlyEvent_BAO_MembersOnlyEvent extends CRM_MembersOnlyEvent_DAO
       'sequential' => 1,
       'is_groups_only' => 1,
       'event_id' => ['IN' => $eventIDs],
-      'return' => ['id', 'event_id'],
+      'return' => ['id', 'event_id', 'notice_for_access_denied'],
       'options' => ['limit' => 0],
     ]);
 

--- a/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
+++ b/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
@@ -225,7 +225,7 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
     $events = [];
     foreach ($eventIDs as $eventID) {
       $groups = $groupsKeyedByEventID[$eventID] ?? [];
-      $allowedGroupsWhichUserBelongsTo = array_intersect($contactGroupIDs, $groups);
+      $allowedGroupsWhichUserBelongsTo = array_values(array_intersect($contactGroupIDs, $groups));
       $membersOnlyEventID = $eventIDAndMembersOnlyEventIDMap[$eventID] ?? NULL;
       $notice_for_access_denied = $membersOnlyEvents[$membersOnlyEventID]['notice_for_access_denied'] ?? '';
       $events[] = [

--- a/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
+++ b/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
@@ -210,6 +210,7 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
   public static function getEventAccessDetails($eventIDs) {
     $membersOnlyEvents = MembersOnlyEvent::getMembersOnlyEvents($eventIDs);
     $membersOnlyEvents = ArrayUtils::keyBy($membersOnlyEvents, 'id');
+    $eventIDAndMembersOnlyEventIDMap = array_column($membersOnlyEvents, 'id', 'event_id');
     $eventGroups = EventGroup::getEventGroups(array_keys($membersOnlyEvents));
     $groupsKeyedByEventID = [];
     foreach ($eventGroups as $eventGroup) {
@@ -225,12 +226,15 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
     foreach ($eventIDs as $eventID) {
       $groups = $groupsKeyedByEventID[$eventID] ?? [];
       $allowedGroupsWhichUserBelongsTo = array_intersect($contactGroupIDs, $groups);
+      $membersOnlyEventID = $eventIDAndMembersOnlyEventIDMap[$eventID] ?? NULL;
+      $notice_for_access_denied = $membersOnlyEvents[$membersOnlyEventID]['notice_for_access_denied'] ?? '';
       $events[] = [
         'event_id' => $eventID,
         'is_groups_only_event' => !empty($groupsKeyedByEventID[$eventID]),
         'allowed_groups' => $groups,
         'is_user_in_any_allowed_group' => !empty($allowedGroupsWhichUserBelongsTo),
         'allowed_groups_which_user_belongs_to' => $allowedGroupsWhichUserBelongsTo,
+        'notice_for_access_denied' => $notice_for_access_denied,
       ];
     }
 


### PR DESCRIPTION
## Overview
This PR add `notice_for_access_denied` to MembersOnlyEventAccess.get API response.

## Before
The MembersOnlyEventAccess.get API response is 
```json
{
   "is_error":0,
   "version":3,
   "count":2,
   "values":[
      {
         "event_id":"52",
         "is_groups_only_event":"1",
         "allowed_groups":["187"],
         "is_user_in_any_allowed_group":"1",
         "allowed_groups_which_user_belongs_to":{"7": "187"}
      },
      {
         "event_id":"53",
         "is_groups_only_event":"",
         "allowed_groups":[],
         "is_user_in_any_allowed_group":"",
         "allowed_groups_which_user_belongs_to":[]
      }
   ]
}
```

## After
The MembersOnlyEventAccess.get API response is 
```json
{
   "is_error":0,
   "version":3,
   "count":2,
   "values":[
      {
         "event_id":"52",
         "is_groups_only_event":"1",
         "allowed_groups":["187"],
         "is_user_in_any_allowed_group":"1",
         "allowed_groups_which_user_belongs_to":["187"],
         "notice_for_access_denied":"<p>This event is for Members only</p>"
      },
      {
         "event_id":"53",
         "is_groups_only_event":"",
         "allowed_groups":[],
         "is_user_in_any_allowed_group":"",
         "allowed_groups_which_user_belongs_to":[],
         "notice_for_access_denied":""
      }
   ]
}
```

## Technical Details
The SSP needs the `notice_for_access_denied` value to display it.
There is another small change to reset the `allowed_groups_which_user_belongs_to` array's keys.