### PR TITLE
MAE-614: Honor Drupal members only event permission.

### DIFF
--- a/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
+++ b/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
@@ -60,13 +60,8 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
    *   True if has access or False otherwise
    */
   public function userHasEventAccess() {
-    if (!$this->contactID) {
-      // the user is not logged-in so he cannot access the event
-      return FALSE;
-    }
-
     if (empty($this->membersOnlyEvent->is_groups_only) && CRM_Core_Permission::check('members only event registration')) {
-      // Any user with 'members only event registration' permission
+      // Any user (including anonymous) with 'members only event registration' permission
       // can access any members-only event.
       return TRUE;
     }


### PR DESCRIPTION
## Overview
This PR allows anonymous users to access the events registration page if they're granted the `members only event registration` permission


## Before
![MembersOnly Event - anonymous](https://user-images.githubusercontent.com/85277674/137116513-83f78a3b-98e9-464a-aaa9-080da99e05b4.gif)


## After
![after-member](https://user-images.githubusercontent.com/85277674/137117861-a3e1830b-5e5e-4daa-b7ef-3528dfe25d4a.gif)
