### PR TITLE
RSE-1719: Fix logical error preventing event register button from sho…

### DIFF
--- a/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
+++ b/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
@@ -60,7 +60,10 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
    *   True if has access or False otherwise
    */
   public function userHasEventAccess() {
-    if (empty($this->membersOnlyEvent->is_groups_only) && CRM_Core_Permission::check('members only event registration')) {
+    if (
+      empty($this->membersOnlyEvent) ||
+      CRM_Core_Permission::check('members only event registration')
+    ) {
       // Any user (including anonymous) with 'members only event registration' permission
       // can access any members-only event.
       return TRUE;


### PR DESCRIPTION
## Overview
The PR https://github.com/compucorp/uk.co.compucorp.membersonlyevent/pull/24 assumed that the permission  `members only event registration` must be enabled if register button needs to appear for anonymous users, which is not the case for event that are not even `members only event`.


## Before
![image](https://user-images.githubusercontent.com/85277674/142587284-2e5620bd-72a8-4bc1-82b2-b62fe3d7db53.png)

## After
![image](https://user-images.githubusercontent.com/85277674/142587310-deacc22d-ea01-4c9c-8d7f-5ebdc64d4220.png)

## Technical Details
A register button would now appear for an event if either of the condition is met

1. It is not a member only event
2. The permission `members only event registration` is enabled for the user.

