### PR TITLE
MAE-358: Display the Member only event settings link under event configurations menu

### DIFF
--- a/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
+++ b/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
@@ -40,6 +40,14 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
   const OPERATION_DOWNGRADE_TO_NORMAL_EVENT = 'downgrade_to_normal_event';
 
   /**
+   * Set variables up before form is built.
+   */
+  public function preProcess() {
+    parent::preProcess();
+    $this->setSelectedChild('membersonlyevent');
+  }
+
+  /**
    * @inheritdoc
    */
   public function buildQuickForm() {

--- a/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
+++ b/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
@@ -40,7 +40,7 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
   const OPERATION_DOWNGRADE_TO_NORMAL_EVENT = 'downgrade_to_normal_event';
 
   /**
-   * Set variables up before form is built.
+   * Sets variables up before form is built.
    */
   public function preProcess() {
     parent::preProcess();

--- a/CRM/MembersOnlyEvent/Hook/Tabset/Event.php
+++ b/CRM/MembersOnlyEvent/Hook/Tabset/Event.php
@@ -21,6 +21,7 @@ class CRM_MembersOnlyEvent_Hook_Tabset_Event {
 
     if (empty($context['event_id'])) {
       $this->addMembersOnlyEventLinkToContextMenu($tabs);
+
       return;
     }
 
@@ -81,7 +82,7 @@ class CRM_MembersOnlyEvent_Hook_Tabset_Event {
     $tab['membersonlyevent'] = [
       'title' => ts('Members Only Event Settings'),
       'url' => $url,
-      'field' => 'id',
+      'field' => 'is_online_registration',
     ];
 
     //Insert this tab into position 4 (after `Online Registration` tab)

--- a/CRM/MembersOnlyEvent/Hook/Tabset/Event.php
+++ b/CRM/MembersOnlyEvent/Hook/Tabset/Event.php
@@ -19,6 +19,11 @@ class CRM_MembersOnlyEvent_Hook_Tabset_Event {
       return;
     }
 
+    if (empty($context['event_id'])) {
+      $this->addMembersOnlyEventLinkToContextMenu($tabs);
+      return;
+    }
+
     $eventID = $context['event_id'];
     $this->addMembersOnlyEventTab($eventID, $tabs);
   }
@@ -35,7 +40,7 @@ class CRM_MembersOnlyEvent_Hook_Tabset_Event {
   private function shouldHandle($tabsetName, &$tabs, $context) {
     $canEditAllEvents = CRM_Core_Permission::check(['edit all events']);
     $isManageEventTabset = ($tabsetName === 'civicrm/event/manage');
-    if (!empty($context['event_id']) && $isManageEventTabset && $canEditAllEvents) {
+    if ($isManageEventTabset && $canEditAllEvents) {
       return TRUE;
     }
     return FALSE;
@@ -57,6 +62,26 @@ class CRM_MembersOnlyEvent_Hook_Tabset_Event {
       'active' => TRUE,
       'current' => FALSE,
       'class' => 'ajaxForm',
+    ];
+
+    //Insert this tab into position 4 (after `Online Registration` tab)
+    $tabs = array_merge(
+      array_slice($tabs, 0, 4),
+      $tab,
+      array_slice($tabs, 4)
+    );
+  }
+
+  /**
+   * @param $tabs
+   */
+  public function addMembersOnlyEventLinkToContextMenu(&$tabs) {
+    $url = 'civicrm/event/manage/membersonlyevent';
+
+    $tab['membersonlyevent'] = [
+      'title' => ts('Members Only Event Settings'),
+      'url' => $url,
+      'field' => 'id',
     ];
 
     //Insert this tab into position 4 (after `Online Registration` tab)


### PR DESCRIPTION
## Overview
This PR adds the Member-only event settings under the event configurations menu.

## Before
<img width="1073" alt="Screenshot 2022-04-26 at 08 50 04" src="https://user-images.githubusercontent.com/85277674/165249672-23a03768-d916-423e-a383-56706573d9ff.png">

## After
![lop](https://user-images.githubusercontent.com/85277674/165468331-e53e6bac-983c-4b15-9ccf-86bd733ea9f5.gif)


