### PR TITLE
WHF-308: Redirect the user to event info page

### DIFF
--- a/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
+++ b/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
@@ -1,7 +1,6 @@
 <?php
 
 use CRM_MembersOnlyEvent_Hook_PageRun_Base as PageRunBase;
-use CRM_MembersOnlyEvent_BAO_MembersOnlyEvent as MembersOnlyEvent;
 use CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess as MembersOnlyEventAccessService;
 
 /**
@@ -46,8 +45,6 @@ class CRM_MembersOnlyEvent_Hook_PageRun_Register extends PageRunBase {
     }
 
     $this->hideEventInfoPageRegisterButton();
-
-    $this->handleAccessOptionForUser();
   }
 
   /**
@@ -88,58 +85,6 @@ class CRM_MembersOnlyEvent_Hook_PageRun_Register extends PageRunBase {
       ->update('default', [
         'disabled' => TRUE,
       ]);
-  }
-
-  /**
-   * Handles access options for logged / anonymous user.
-   */
-  private function handleAccessOptionForUser() {
-    $membersOnlyEvent = $this->membersOnlyEventAccessService->getMembersOnlyEvent();
-
-    if ($membersOnlyEvent->is_showing_purchase_membership_block) {
-      $this->addMembershipPurchaseButtonToEventInfoPage($membersOnlyEvent);
-      $userLoggedIn = CRM_Core_Session::getLoggedInContactID();
-      if ($userLoggedIn) {
-        return;
-      }
-      $loginURL = CRM_Core_Config::singleton()->userSystem->getLoginURL();
-      $infoText = 'This event is for members only, if you have a current, pending or former membership
-                 please log in before purchase membership. If you are not a current member you will be charged
-                 an additional membership fee. <a href="' . $loginURL . '">Click here to login </a>';
-      CRM_Core_Session::setStatus(ts($infoText));
-
-    }
-    else {
-      // Purchase membership button is disabled, so we will just show the configured notice message
-      CRM_Core_Session::setStatus($membersOnlyEvent->notice_for_access_denied);
-    }
-  }
-
-  /**
-   * Adds membership purchase button based
-   * on the members-only event configurations to
-   * the header and the footer of the event info page.
-   *
-   * @param \CRM_MembersOnlyEvent_DAO_MembersOnlyEvent $membersOnlyEvent
-   */
-  private function addMembershipPurchaseButtonToEventInfoPage($membersOnlyEvent) {
-    switch ($membersOnlyEvent->purchase_membership_link_type) {
-      case MembersOnlyEvent::LINK_TYPE_CONTRIBUTION_PAGE:
-        $contributionPageID = $membersOnlyEvent->contribution_page_id;
-        $path = 'civicrm/contribute/transact';
-        $params = 'reset=1&id=' . $contributionPageID;
-        $membershipPurchaseURL = CRM_Utils_System::url($path, $params);
-        break;
-
-      case MembersOnlyEvent::LINK_TYPE_URL:
-      default:
-        $membershipPurchaseURL = $membersOnlyEvent->purchase_membership_url;
-        break;
-    }
-
-    $buttonText = $membersOnlyEvent->purchase_membership_button_label;
-
-    $this->addActionButtonToEventInfoPage($membershipPurchaseURL, $buttonText);
   }
 
   /**

--- a/CRM/MembersOnlyEvent/Hook/PreProcess/Register.php
+++ b/CRM/MembersOnlyEvent/Hook/PreProcess/Register.php
@@ -43,8 +43,7 @@ class CRM_MembersOnlyEvent_Hook_PreProcess_Register extends PreProcessBase {
    * Hence that users are supposed to register for events
    * from the info page, so in case the user tired to access
    * the registration page directly we will just redirect him
-   * to the main page instead of showing any error or buttons to
-   * login or buy membership.
+   * to the info page.
    *
    * @param $formName
    * @param CRM_Event_Form_Registration_Register $form

--- a/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
+++ b/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
@@ -188,8 +188,15 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
    */
   public function redirectUsersWithoutEventAccess() {
     if (!$this->userHasEventAccess()) {
-      // if the user has no access, redirect to the main page
-      CRM_Utils_System::redirect('/');
+      // if the user has no access, redirect to the event info page.
+      $id = CRM_Utils_Request::retrieve('id', 'Positive');
+      $params = 'id=' . $id;
+      if ($reset = CRM_Utils_Request::retrieve('reset', 'Positive')) {
+        $params .= '&reset=' . $reset;
+      }
+
+      $url = CRM_Utils_System::url('civicrm/event/info', $params);
+      CRM_Utils_System::redirect($url);
     }
   }
 


### PR DESCRIPTION
## Overview
This PR redirects the user who tries to access the event registration page to event info page, and removes old code.

## Before

https://user-images.githubusercontent.com/74309109/181461613-4ea7216d-99ec-4b9f-87ea-a03605bee175.mp4


## After

https://user-images.githubusercontent.com/74309109/181461639-1e74056d-51f6-4f9b-96ec-303f0c49be78.mp4


