### PR TITLE
WHF-366: Add default text for message fields

### DIFF
--- a/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
+++ b/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
@@ -323,13 +323,13 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
   private function setInitialValues(&$defaultValues) {
     $defaultValues['event_access_type'] = self::NO_SELECTED;
     $defaultValues['is_showing_custom_access_denied_message'] = self::NO_SELECTED;
-    $defaultValues['notice_for_access_denied'] = ts('Access Denied');
+    $defaultValues['notice_for_access_denied'] = ts('Access to this event is restricted');
     $defaultValues['is_showing_login_block'] = self::NO_SELECTED;
     $defaultValues['block_type'] = 1;
-    $defaultValues['login_block_message'] = '';
+    $defaultValues['login_block_message'] = ts('To access this event, please login below');
     $defaultValues['is_showing_purchase_membership_block'] = self::NO_SELECTED;
     $defaultValues['purchase_membership_button_label'] = ts('Purchase membership to book the event');
-    $defaultValues['purchase_membership_body_text'] = '';
+    $defaultValues['purchase_membership_body_text'] = ts('Become a member to get access to this event');
     $defaultValues['purchase_membership_link_type'] = MembersOnlyEvent::LINK_TYPE_URL;
   }
 


### PR DESCRIPTION
## Overview
This PR adds default text for message fields.

## Before
![Screenshot from 2022-08-04 10-47-30](https://user-images.githubusercontent.com/74309109/182794700-91be17f9-f068-4e80-a08f-c5fb698b4c18.png)
![Screenshot from 2022-08-04 10-47-36](https://user-images.githubusercontent.com/74309109/182794711-fceedf1f-521f-4d6b-a119-5d51e47cc8ad.png)
![Screenshot from 2022-08-04 10-47-41](https://user-images.githubusercontent.com/74309109/182794730-4884013d-f8f2-42ba-981f-7a0854cc9907.png)

## After
![Screenshot from 2022-08-04 10-55-20](https://user-images.githubusercontent.com/74309109/182794653-ec8eb3b2-abb3-4a66-a869-4a1efcb673e4.png)
![Screenshot from 2022-08-04 10-55-27](https://user-images.githubusercontent.com/74309109/182794669-b66d48ad-c18b-4335-bbbe-72457d25ee46.png)
![Screenshot from 2022-08-04 10-55-36](https://user-images.githubusercontent.com/74309109/182794680-c7af9ec9-499f-40bc-85de-5bc6356e11ae.png)

