### PR TITLE
WHF-368: Add blocks on non SSP sites

### DIFF
--- a/CRM/MembersOnlyEvent/BAO/MembersOnlyEvent.php
+++ b/CRM/MembersOnlyEvent/BAO/MembersOnlyEvent.php
@@ -38,6 +38,20 @@ class CRM_MembersOnlyEvent_BAO_MembersOnlyEvent extends CRM_MembersOnlyEvent_DAO
   const EVENT_ACCESS_TYPE_AUTHENTICATED_ONLY = 3;
 
   /**
+   * Block type for 'Login block only'.
+   *
+   * @const int
+   */
+  const BLOCK_TYPE_LOGIN_ONLY = 1;
+
+  /**
+   * Block type for 'Login or register block'.
+   *
+   * @const int
+   */
+  const BLOCK_TYPE_LOGIN_OR_REGISTER_BLOCK = 2;
+
+  /**
    * Creates a new Members-Only Event record
    * based on array-data
    *

--- a/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
+++ b/CRM/MembersOnlyEvent/Form/MembersOnlyEventTab.php
@@ -325,7 +325,7 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
     $defaultValues['is_showing_custom_access_denied_message'] = self::NO_SELECTED;
     $defaultValues['notice_for_access_denied'] = ts('Access to this event is restricted');
     $defaultValues['is_showing_login_block'] = self::NO_SELECTED;
-    $defaultValues['block_type'] = 1;
+    $defaultValues['block_type'] = MembersOnlyEvent::BLOCK_TYPE_LOGIN_ONLY;
     $defaultValues['login_block_message'] = ts('To access this event, please login below');
     $defaultValues['is_showing_purchase_membership_block'] = self::NO_SELECTED;
     $defaultValues['purchase_membership_button_label'] = ts('Purchase membership to book the event');
@@ -454,11 +454,11 @@ class CRM_MembersOnlyEvent_Form_MembersOnlyEventTab extends CRM_Event_Form_Manag
    */
   private function getBlockTypes() {
     $block_types = [
-      '1' => ts('Login only'),
+      MembersOnlyEvent::BLOCK_TYPE_LOGIN_ONLY => ts('Login only'),
     ];
 
     if (function_exists('module_exists') && module_exists('ssp_core_user')) {
-      $block_types['2'] = ts('Login or register block');
+      $block_types[MembersOnlyEvent::BLOCK_TYPE_LOGIN_OR_REGISTER_BLOCK] = ts('Login or register block');
     }
 
     return $block_types;

--- a/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
+++ b/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
@@ -45,6 +45,8 @@ class CRM_MembersOnlyEvent_Hook_PageRun_Register extends PageRunBase {
     }
 
     $this->hideEventInfoPageRegisterButton();
+
+    $this->addbocks();
   }
 
   /**
@@ -84,6 +86,19 @@ class CRM_MembersOnlyEvent_Hook_PageRun_Register extends PageRunBase {
     CRM_Core_Region::instance('event-page-eventinfo-actionlinks-bottom')
       ->update('default', [
         'disabled' => TRUE,
+      ]);
+  }
+
+  /**
+   * Adds the access denied, login and membership blocks.
+   */
+  private function addbocks() {
+    $membersOnlyEvent = $this->membersOnlyEventAccessService->getMembersOnlyEvent();
+
+    CRM_Core_Region::instance('event-page-eventinfo-actionlinks-bottom')
+      ->add([
+        'template' => 'CRM/Event/Page/blocks.tpl',
+        'membersOnlyEvent' => (array) $membersOnlyEvent,
       ]);
   }
 

--- a/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
+++ b/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
@@ -127,29 +127,4 @@ class CRM_MembersOnlyEvent_Hook_PageRun_Register extends PageRunBase {
       ]);
   }
 
-  /**
-   * Adds a button with the specified
-   * url and text to the header and the footer
-   * of the event info page.
-   *
-   * @param $url
-   * @param $buttonText
-   */
-  public function addActionButtonToEventInfoPage($url, $buttonText) {
-    $buttonToAdd = [
-      'template' => 'CRM/Event/Page/members-event-button.tpl',
-      'button_text' => ts($buttonText),
-      'position' => 'top',
-      'url' => $url,
-      'weight' => -10,
-    ];
-
-    CRM_Core_Region::instance('event-page-eventinfo-actionlinks-top')
-      ->add($buttonToAdd);
-
-    $buttonToAdd['position'] = 'bottom';
-    CRM_Core_Region::instance('event-page-eventinfo-actionlinks-bottom')
-      ->add($buttonToAdd);
-  }
-
 }

--- a/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
+++ b/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
@@ -93,12 +93,12 @@ class CRM_MembersOnlyEvent_Hook_PageRun_Register extends PageRunBase {
    * Adds the access denied, login and membership blocks.
    */
   private function addbocks() {
-    $membersOnlyEvent = $this->membersOnlyEventAccessService->getMembersOnlyEvent();
+    $membersOnlyEvent = $this->membersOnlyEventAccessService->prepareMembersOnlyEventForTemplate();
 
     CRM_Core_Region::instance('event-page-eventinfo-actionlinks-bottom')
       ->add([
         'template' => 'CRM/Event/Page/blocks.tpl',
-        'membersOnlyEvent' => (array) $membersOnlyEvent,
+        'membersOnlyEvent' => $membersOnlyEvent,
       ]);
   }
 

--- a/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
+++ b/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
@@ -90,9 +90,34 @@ class CRM_MembersOnlyEvent_Hook_PageRun_Register extends PageRunBase {
   }
 
   /**
+   * Checks whether the ssp_bootstrap is the active theme or not.
+   */
+  private function isSSPBootstrapTheActiveTheme() {
+    $config = CRM_Core_Config::singleton();
+
+    if (!$config->userSystem->is_drupal) {
+      return FALSE;
+    }
+
+    // Connot trust the value of `variable_get('theme_default')` if the module
+    // themekey was enabled because the module switch the theme without updating
+    // the `theme_default` variable.
+    if ($GLOBALS['theme_key'] !== 'ssp_bootstrap') {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
    * Adds the access denied, login and membership blocks.
    */
   private function addbocks() {
+    if ($this->isSSPBootstrapTheActiveTheme()) {
+      // Skip adding the blocks, the theme uses a custom template.
+      return;
+    }
+
     $membersOnlyEvent = $this->membersOnlyEventAccessService->prepareMembersOnlyEventForTemplate();
 
     CRM_Core_Region::instance('event-page-eventinfo-actionlinks-bottom')

--- a/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
+++ b/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
@@ -231,7 +231,8 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
     }
 
     if (!empty($membersOnlyEvent['is_showing_login_block'])) {
-      if ($membersOnlyEvent['block_type'] === "1") {
+      $block_type = (int) $membersOnlyEvent['block_type'];
+      if ($block_type === MembersOnlyEvent::BLOCK_TYPE_LOGIN_ONLY) {
         $user_login_form_content = '';
         if ($config->userSystem->is_drupal) {
           $user_login_form = drupal_get_form('user_login');
@@ -243,6 +244,7 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
           $user_login_form['#action'] .= $query_string_prefix . 'destination=' . urlencode($register_page);
           $user_login_form_content = drupal_render($user_login_form);
         }
+
         $membersOnlyEvent['login_block_content'] = $user_login_form_content;
         $membersOnlyEvent['login_block_header'] = '<h2>' . ts('Login') . '</h2>';
       }
@@ -252,6 +254,7 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
           $user_login_form = drupal_get_form('ssp_core_user_login_or_register_form');
           $user_login_form_content = drupal_render($user_login_form);
         }
+
         $membersOnlyEvent['login_block_content'] = $user_login_form_content;
         $membersOnlyEvent['login_block_header'] = '<h2>' . ts('Login or Register') . '</h2>';
       }

--- a/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
+++ b/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
@@ -230,7 +230,11 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
         if ($config->userSystem->is_drupal) {
           $user_login_form = drupal_get_form('user_login');
           $register_page = '/civicrm/event/register?reset=1&id=' . $membersOnlyEvent['event_id'];
-          $user_login_form['#action'] .= '?destination=' . urlencode($register_page);
+          $query_string_prefix = "?";
+          if (strpos($user_login_form['#action'], '?') !== FALSE) {
+            $query_string_prefix = "&";
+          }
+          $user_login_form['#action'] .= $query_string_prefix . 'destination=' . urlencode($register_page);
           $user_login_form_content = drupal_render($user_login_form);
         }
         $membersOnlyEvent['login_block_content'] = $user_login_form_content;

--- a/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
+++ b/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
@@ -213,6 +213,35 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
   }
 
   /**
+   * Prepares members-only event for template.
+   *
+   * @return array
+   *   The membersOnlyEvent details.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function prepareMembersOnlyEventForTemplate() {
+    $membersOnlyEvent = (array) $this->membersOnlyEvent;
+
+    if (!empty($membersOnlyEvent['is_showing_login_block'])) {
+      if ($membersOnlyEvent['block_type'] === "1") {
+        $user_login_form = drupal_get_form('user_login');
+        $register_page = '/civicrm/event/register?reset=1&id=' . $membersOnlyEvent['event_id'];
+        $user_login_form['#action'] .= '?destination=' . urlencode($register_page);
+        $membersOnlyEvent['login_block_content'] = drupal_render($user_login_form);
+        $membersOnlyEvent['login_block_header'] = '<h2>' . ts('Login') . '</h2>';
+      }
+      else {
+        $user_login_form = drupal_get_form('ssp_core_user_login_or_register_form');
+        $membersOnlyEvent['login_block_content'] = drupal_render($user_login_form);
+        $membersOnlyEvent['login_block_header'] = '<h2>' . ts('Login or Register') . '</h2>';
+      }
+    }
+
+    return $membersOnlyEvent;
+  }
+
+  /**
    * Gets event access details for a given event ids
    *
    * @param array $eventIDs

--- a/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
+++ b/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
@@ -238,6 +238,14 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
       }
     }
 
+    if (!empty($membersOnlyEvent['is_showing_purchase_membership_block'])) {
+      if ($membersOnlyEvent['purchase_membership_link_type'] === "0") {
+        $path = 'civicrm/contribute/transact';
+        $params = 'reset=1&id=' . $membersOnlyEvent['contribution_page_id'];
+        $membersOnlyEvent['purchase_membership_url'] = CRM_Utils_System::url($path, $params);
+      }
+    }
+
     return $membersOnlyEvent;
   }
 

--- a/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
+++ b/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
@@ -224,6 +224,12 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
     $membersOnlyEvent = (array) $this->membersOnlyEvent;
     $config = CRM_Core_Config::singleton();
 
+    $contactId = CRM_Core_Session::getLoggedInContactID();
+    if ($contactId) {
+      // Logged in users cannot see the login form and will be redirected.
+      $membersOnlyEvent['is_showing_login_block'] = "0";
+    }
+
     if (!empty($membersOnlyEvent['is_showing_login_block'])) {
       if ($membersOnlyEvent['block_type'] === "1") {
         $user_login_form_content = '';

--- a/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
+++ b/CRM/MembersOnlyEvent/Service/MembersOnlyEventAccess.php
@@ -222,18 +222,27 @@ class CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess {
    */
   public function prepareMembersOnlyEventForTemplate() {
     $membersOnlyEvent = (array) $this->membersOnlyEvent;
+    $config = CRM_Core_Config::singleton();
 
     if (!empty($membersOnlyEvent['is_showing_login_block'])) {
       if ($membersOnlyEvent['block_type'] === "1") {
-        $user_login_form = drupal_get_form('user_login');
-        $register_page = '/civicrm/event/register?reset=1&id=' . $membersOnlyEvent['event_id'];
-        $user_login_form['#action'] .= '?destination=' . urlencode($register_page);
-        $membersOnlyEvent['login_block_content'] = drupal_render($user_login_form);
+        $user_login_form_content = '';
+        if ($config->userSystem->is_drupal) {
+          $user_login_form = drupal_get_form('user_login');
+          $register_page = '/civicrm/event/register?reset=1&id=' . $membersOnlyEvent['event_id'];
+          $user_login_form['#action'] .= '?destination=' . urlencode($register_page);
+          $user_login_form_content = drupal_render($user_login_form);
+        }
+        $membersOnlyEvent['login_block_content'] = $user_login_form_content;
         $membersOnlyEvent['login_block_header'] = '<h2>' . ts('Login') . '</h2>';
       }
       else {
-        $user_login_form = drupal_get_form('ssp_core_user_login_or_register_form');
-        $membersOnlyEvent['login_block_content'] = drupal_render($user_login_form);
+        $user_login_form_content = '';
+        if ($config->userSystem->is_drupal) {
+          $user_login_form = drupal_get_form('ssp_core_user_login_or_register_form');
+          $user_login_form_content = drupal_render($user_login_form);
+        }
+        $membersOnlyEvent['login_block_content'] = $user_login_form_content;
         $membersOnlyEvent['login_block_header'] = '<h2>' . ts('Login or Register') . '</h2>';
       }
     }

--- a/CRM/MembersOnlyEvent/Test/Fabricator/MembersOnlyEvent.php
+++ b/CRM/MembersOnlyEvent/Test/Fabricator/MembersOnlyEvent.php
@@ -32,7 +32,7 @@ class CRM_MembersOnlyEvent_Test_Fabricator_MembersOnlyEvent {
       'is_showing_custom_access_denied_message' => 1,
       'notice_for_access_denied' => 'Access Denied',
       'is_showing_login_block' => 1,
-      'block_type' => 1,
+      'block_type' => MembersOnlyEvent::BLOCK_TYPE_LOGIN_ONLY,
       'login_block_message' => 'Please Login',
       'is_showing_purchase_membership_block' => 1,
       'purchase_membership_button_label' => 'Purchase membership to book the event',

--- a/api/v3/MembersOnlyEvent.php
+++ b/api/v3/MembersOnlyEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_MembersOnlyEvent_Service_MembersOnlyEventAccess as MembersOnlyEventAccessService;
+
 /**
  * MembersOnlyEvent.create API specification (optional)
  * This is used for documentation and validation.
@@ -42,5 +44,20 @@ function civicrm_api3_members_only_event_delete($params) {
  * @throws API_Exception
  */
 function civicrm_api3_members_only_event_get($params) {
-  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  $result = _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  if ($result['count'] < 1) {
+    return $result;
+  }
+
+  foreach ($result['values'] as $key => $value) {
+    $membersOnlyEventAccessService = new MembersOnlyEventAccessService($value['event_id']);
+    $membersOnlyEvent = $membersOnlyEventAccessService->prepareMembersOnlyEventForTemplate();
+
+    $result['values'][$key]['login_block_content'] = $membersOnlyEvent['login_block_content'] ?? '';
+    $result['values'][$key]['login_block_header'] = $membersOnlyEvent['login_block_header'] ?? '';
+    $result['values'][$key]['purchase_membership_url'] = $membersOnlyEvent['purchase_membership_url'] ?? '';
+    $result['values'][$key]['is_user_allowed'] = $membersOnlyEventAccessService->userHasEventAccess();
+  }
+
+  return $result;
 }

--- a/templates/CRM/Event/Page/blocks.tpl
+++ b/templates/CRM/Event/Page/blocks.tpl
@@ -15,3 +15,18 @@
     {$snippet.membersOnlyEvent.login_block_content}
   </div>
 {/if}
+
+{if !empty($snippet.membersOnlyEvent.is_showing_purchase_membership_block)}
+  <br>
+  <hr>
+  <div class="crm-section purchase_membership-section">
+    <div class="label">{$snippet.membersOnlyEvent.purchase_membership_button_label}</div>
+    <div class="content">
+      {$snippet.membersOnlyEvent.purchase_membership_body_text}
+      <a href="{$snippet.membersOnlyEvent.purchase_membership_url}" class="button">{$snippet.membersOnlyEvent.purchase_membership_button_label}</a>
+    </div>
+    <div class="clear"></div>
+  </div>
+  <br>
+  <br>
+{/if}

--- a/templates/CRM/Event/Page/blocks.tpl
+++ b/templates/CRM/Event/Page/blocks.tpl
@@ -1,0 +1,7 @@
+{if !empty($snippet.membersOnlyEvent.is_showing_custom_access_denied_message)}
+  <br>
+  <hr>
+  <div class="crm-section access_denied-section">
+    {$snippet.membersOnlyEvent.notice_for_access_denied}
+  </div>
+{/if}

--- a/templates/CRM/Event/Page/blocks.tpl
+++ b/templates/CRM/Event/Page/blocks.tpl
@@ -5,3 +5,13 @@
     {$snippet.membersOnlyEvent.notice_for_access_denied}
   </div>
 {/if}
+
+{if !empty($snippet.membersOnlyEvent.is_showing_login_block)}
+  <br>
+  <hr>
+  <div class="crm-section login-section">
+    {$snippet.membersOnlyEvent.login_block_header}
+    {$snippet.membersOnlyEvent.login_block_message}
+    {$snippet.membersOnlyEvent.login_block_content}
+  </div>
+{/if}

--- a/tests/phpunit/CRM/MembersOnlyEvent/BAO/MembersOnlyEventTest.php
+++ b/tests/phpunit/CRM/MembersOnlyEvent/BAO/MembersOnlyEventTest.php
@@ -24,7 +24,7 @@ class CRM_MembersOnlyEvent_BAO_MembersOnlyEventTest extends BaseHeadlessTest {
       'is_showing_custom_access_denied_message' => 1,
       'notice_for_access_denied' => '<p>Access Denied</p>',
       'is_showing_login_block' => 1,
-      'block_type' => 1,
+      'block_type' => MembersOnlyEvent::BLOCK_TYPE_LOGIN_ONLY,
       'login_block_message' => '<p>Please login</p>',
       'is_showing_purchase_membership_block' => 1,
       'purchase_membership_button_label' => 'Purchase membership to book the event',


### PR DESCRIPTION
## Overview
This PR adds the access denied, login and purchase membership blocks to the event info page.

## Before
The blocks don't exist.

![Screenshot from 2022-08-11 13-43-45](https://user-images.githubusercontent.com/74309109/184116977-509507d0-81e5-436e-b960-4be3fca4ba5b.png)


## After
The blocks do exist.

https://user-images.githubusercontent.com/74309109/184116992-82fdbbe5-a85d-4b3a-a9d4-c2bf906f69e0.mp4


I tried it with different themes (Drupal's Garland with CiviCRM's greenwich) 
![Screenshot from 2022-08-11 16-20-46](https://user-images.githubusercontent.com/74309109/184142906-bd8b2dea-598d-4a36-a920-b1aaca3f53f5.png)
![Screenshot from 2022-08-11 16-20-26](https://user-images.githubusercontent.com/74309109/184142910-8577bdad-e5e0-49f4-a608-2597dcea0417.png)



https://user-images.githubusercontent.com/74309109/184142879-24740a05-af26-40f8-8df9-21c4dc8d54a3.mp4




## Technical Details
First, I created the template `templates/CRM/Event/Page/blocks.tpl` with the access denied block and added it to the region `event-page-eventinfo-actionlinks-bottom`.

Second, I created the method `MembersOnlyEventAccess::prepareMembersOnlyEventForTemplate` to pre-process the `$membersOnlyEvent` object and to render the form, the return value of that method was used to create the login block in the template.

Third, updated the method `prepareMembersOnlyEventForTemplate` to prepare the `purchase_membership_url` and updated the template with the purchase membership block.

Fourth, CiviCRM is available for multiple CMSes/platforms and the login block needs to gracefully handle that. In our case, we don't show the login form if the platform is not Drupal.

Fifth, I skipped adding the blocks when ssp_bootstrap is the active theme because the theme uses a custom template.

Sixth, I removed the unused method `addActionButtonToEventInfoPage` because the purchase membership already provides a button.

Seventh, fixed an issue with the login form, CiviCRM throw the following error after the form submission:
```
id (value: 1?destination=/civicrm/event/register?reset=1&amp;id=) is not of the type Positive
```
This happens because the URL has two question marks like : 
```
https://site.com/civicrm/event/info?reset=1&id=1?destination=/civicrm/event/register?reset=1&id=`
```

https://user-images.githubusercontent.com/74309109/184147111-bc0d2497-eab3-4ae0-af36-0d6910359cfb.mp4

Eighth, updated the login block to render it for anonymous users only. Logged in users cannot see the login form and will be redirected.


https://user-images.githubusercontent.com/74309109/184193352-f3929c03-68a6-4dbd-966a-b28ec5e694e6.mp4


Nineth, added more properties to membersOnlyEvent when querying it through CiviCRM API like :
- is_user_allowed: Tells whether the current user is allowed to register or not.
- login_block_header.
- login_block_content.
- purchase_membership_url.

The main point is keep the logic in one place (inside the extension) and any module/extension can use the CiviCRM api to query the data .e.g use login_block values instead of writing code to figure out which login block to show. The ssp_core PR https://github.com/compucorp/ssp_core/pull/361 depends on these new properties.

Lastly, created class constants for block types.