### PR TITLE
WHF-372: Hide the login block for authenticated users

### DIFF
--- a/api/v3/MembersOnlyEvent.php
+++ b/api/v3/MembersOnlyEvent.php
@@ -53,9 +53,10 @@ function civicrm_api3_members_only_event_get($params) {
     $membersOnlyEventAccessService = new MembersOnlyEventAccessService($value['event_id']);
     $membersOnlyEvent = $membersOnlyEventAccessService->prepareMembersOnlyEventForTemplate();
 
+    $result['values'][$key]['is_showing_login_block'] = $membersOnlyEvent['is_showing_login_block'];
     $result['values'][$key]['login_block_content'] = $membersOnlyEvent['login_block_content'] ?? '';
     $result['values'][$key]['login_block_header'] = $membersOnlyEvent['login_block_header'] ?? '';
-    $result['values'][$key]['purchase_membership_url'] = $membersOnlyEvent['purchase_membership_url'] ?? '';
+    $result['values'][$key]['purchase_membership_url'] = $membersOnlyEvent['purchase_membership_url'];
     $result['values'][$key]['is_user_allowed'] = $membersOnlyEventAccessService->userHasEventAccess();
   }
 


### PR DESCRIPTION
## Overview
This PR hides the login block for authenticated users. In some cases the authenticated users are not allowed to register the event (it the event requires certain groups or memberships).

## Before

https://user-images.githubusercontent.com/74309109/184890440-49120dda-ddff-4798-bb6e-6b1b86aa846f.mp4


## After

https://user-images.githubusercontent.com/74309109/184890456-bd82af45-60eb-44fa-84fb-ff650b510544.mp4


## Technical Details
In the  method  `MembersOnlyEventAccess::prepareMembersOnlyEventForTemplate`, we have a condition that renders the login form for the anonymous users only.

```php
  public function prepareMembersOnlyEventForTemplate() {
    ...
    if ($contactId) {
      // Logged in users cannot see the login form and will be redirected.
      $membersOnlyEvent['is_showing_login_block'] = "0";
    }
```

We need to update the file `api/v3/MembersOnlyEvent.php` to catch the updated value if any.