### PR TITLE
WHF-375: Fix rendering the blocks twice issue

### DIFF
--- a/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
+++ b/CRM/MembersOnlyEvent/Hook/PageRun/Register.php
@@ -90,19 +90,15 @@ class CRM_MembersOnlyEvent_Hook_PageRun_Register extends PageRunBase {
   }
 
   /**
-   * Checks whether the ssp_bootstrap is the active theme or not.
+   * Checks whether the ssp_core is enabled or not.
    */
-  private function isSSPBootstrapTheActiveTheme() {
+  private function isSSPCoreEnabled() {
     $config = CRM_Core_Config::singleton();
-
     if (!$config->userSystem->is_drupal) {
       return FALSE;
     }
 
-    // Connot trust the value of `variable_get('theme_default')` if the module
-    // themekey was enabled because the module switch the theme without updating
-    // the `theme_default` variable.
-    if ($GLOBALS['theme_key'] !== 'ssp_bootstrap') {
+    if (!module_exists('ssp_core')) {
       return FALSE;
     }
 
@@ -113,8 +109,8 @@ class CRM_MembersOnlyEvent_Hook_PageRun_Register extends PageRunBase {
    * Adds the access denied, login and membership blocks.
    */
   private function addbocks() {
-    if ($this->isSSPBootstrapTheActiveTheme()) {
-      // Skip adding the blocks, the theme uses a custom template.
+    if ($this->isSSPCoreEnabled()) {
+      // Skip adding the blocks, the module uses a custom template.
       return;
     }
 


### PR DESCRIPTION
## Overview
This PR is a follow up to the PR https://github.com/compucorp/uk.co.compucorp.membersonlyevent/pull/34 to fix rendering the blocks twice. We need to prevent the extension from rendering the blocks if ssp_core was enabled.

## Before
![Screenshot from 2022-08-18 18-32-13](https://user-images.githubusercontent.com/74309109/185435095-d8b9eb9e-7583-4def-8e13-2fc89ae19de9.png)

## After
![Screenshot from 2022-08-18 18-32-31](https://user-images.githubusercontent.com/74309109/185435085-e8a91418-54cd-45d7-b712-dcafd410bd95.png)

# Technical details
checking the `ssp_bootstrap` theme being active was a mistake, because the custom template for event info page is living inside ssp_core repository.
https://github.com/compucorp/ssp_core/blob/7.x-2.10/templates/system/page--box.tpl.php
