### PR TITLE
MAE-888: Update testing workflow to PHP 8 container

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.1.1-php7.2
+    container: compucorp/civicrm-buildkit:1.3.0-php8.0
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -29,14 +29,14 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.35.2 --cms-ver 7.80 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.79 --web-root $GITHUB_WORKSPACE/site
 
       - uses: compucorp/apply-patch@1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           repo: compucorp/civicrm-core
-          version: 5.35.2
+          version: 5.51.3
           path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2

--- a/CRM/MembersOnlyEvent/Test/Fabricator/SmartGroup.php
+++ b/CRM/MembersOnlyEvent/Test/Fabricator/SmartGroup.php
@@ -19,10 +19,11 @@ class CRM_MembersOnlyEvent_Test_Fabricator_SmartGroup {
       $params['title'] = $params['name'];
     }
 
-    // CiviCRM uses this methods in GroupContactCache tests to create a smart
-    // group in the file
-    // tests/phpunit/CRM/Contact/BAO/GroupContactCacheTest.php.
     $group = Group::createSmartGroup($params);
+
+    // Rebuilding the group to add the matching contacts
+    // to it.
+    civicrm_api3('Job', 'group_rebuild');
 
     return $group;
   }


### PR DESCRIPTION
## Overview
Updating the unit-tests container, CiviCRM, and Drupal to the PHP8 version.

After updating them, the following test started to fail: `testIfGetContactAllowedGroupsWorksWithSmartGroups`  with the following error:

```
1) CRM_MembersOnlyEvent_BAO_EventGroupTest::testIfGetContactAllowedGroupsWorksWithSmartGroups
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 7
 )

/__w/uk.co.compucorp.membersonlyevent/uk.co.compucorp.membersonlyevent/site/web/sites/all/modules/civicrm/tools/extensions/uk.co.compucorp.membersonlyevent/tests/phpunit/CRM/MembersOnlyEvent/BAO/EventGroupTest.php:134
/buildkit/civicrm-buildkit/extern/phpunit5/phpunit5.phar:598
```

Reason is that after this Core PR: https://github.com/civicrm/civicrm-core/pull/20243, this line `CRM_Contact_BAO_GroupContactCache::add($group->id);` that used to search for the smart group search criteria  and add them to the group right away after adding the group was removed from core, and  such contacts are now only added when "Rebuild Smart Group Cache" scheduled job runs. 

This core update should not have an impact on this extension except for the failing test, given the test was relying on CiviCRM core to add the contacts to the group, I fixed that by rebuilding the smart group cache right after creating the smart group.
