### PR TITLE
MAE-964: Allow users to create events from a template

### DIFF
--- a/CRM/MembersOnlyEvent/Hook/Copy/Event.php
+++ b/CRM/MembersOnlyEvent/Hook/Copy/Event.php
@@ -15,9 +15,10 @@ class CRM_MembersOnlyEvent_Hook_Copy_Event {
    */
   public function handle(&$object) {
     $templateId = CRM_Utils_Request::retrieve('template_id', 'Int');
-    if (empty(templateId)) {
+    if (empty($templateId)) {
       return;
     }
+
     $eventFromTemplateCreator = new CRM_MembersOnlyEvent_Hook_Copy_EventFromTemplateCreator($object->id, $templateId);
     $eventFromTemplateCreator->create();
   }


### PR DESCRIPTION
## Overview
Allow users to create events from a template

## Before
Users are unable to create events from a template
![MAE-967](https://user-images.githubusercontent.com/85277674/203487498-e722d8a8-bdee-4292-9507-03076c6ff65a.gif)

## After
Users are able to create events from a template
![flog](https://user-images.githubusercontent.com/85277674/203488099-b895a8bd-cc9b-4b24-b0ee-45fafdacf974.gif)