### PR TITLE
MAE-964: Add member-only setting from Event Template if template ID is valid

### DIFF
--- a/CRM/MembersOnlyEvent/Hook/Copy/Event.php
+++ b/CRM/MembersOnlyEvent/Hook/Copy/Event.php
@@ -15,7 +15,7 @@ class CRM_MembersOnlyEvent_Hook_Copy_Event {
    */
   public function handle(&$object) {
     $templateId = CRM_Utils_Request::retrieve('template_id', 'Int');
-    if (empty(templateId)) {
+    if (empty($templateId)) {
       return;
     }
     $eventFromTemplateCreator = new CRM_MembersOnlyEvent_Hook_Copy_EventFromTemplateCreator($object->id, $templateId);


### PR DESCRIPTION
## Overview
Add member-only setting from Event Template if template ID is valid

## Before
Users are unable to create events from a template (PHP8)
![MAE-967](https://user-images.githubusercontent.com/85277674/203487498-e722d8a8-bdee-4292-9507-03076c6ff65a.gif)

## After
Users are able to create events from a template (PHP8)
![flog](https://user-images.githubusercontent.com/85277674/203488099-b895a8bd-cc9b-4b24-b0ee-45fafdacf974.gif)

## Technical Details
In PHP 7.4 and below constants are treated as strings so `template_id` is same as `"template_id"` see the image below

<img width="474" alt="Screenshot 2022-11-23 at 11 43 54" src="https://user-images.githubusercontent.com/85277674/203527227-295ef516-e890-4ec1-8e1a-3719a6721f34.png">
<img width="689" alt="Screenshot 2022-11-23 at 11 39 48" src="https://user-images.githubusercontent.com/85277674/203529182-a24487c8-11d4-44ce-a8c1-dd00563777f2.png">

This explains why the missing `$` didn't result in a syntax error on PHP7.4 and was only reported in PHP8, even though this doesn't cause a syntax error, it would result in logical error.