### PR TITLE
CIVIMM-293: Fix permission label

### DIFF
--- a/membersonlyevent.php
+++ b/membersonlyevent.php
@@ -36,7 +36,10 @@ function membersonlyevent_civicrm_enable() {
  */
 function membersonlyevent_civicrm_permission(&$permissions) {
   $prefix = ts('Members-Only Event') . ': ';
-  $permissions['members only event registration'] = $prefix . ts('Can register for members-only events irrespective of membership status');
+  $permissions['members only event registration'] = [
+    'label' => $prefix . ts('Can register for members-only events irrespective of membership status'),
+    'description' => $prefix . ts('Can register for members-only events irrespective of membership status'),
+  ];
 }
 
 /**


### PR DESCRIPTION
## Overview
This PR fixes the permission label warning

> [PHP User Deprecation] Permission 'members only event registration' should be declared with 'label' and 'description' keys. See https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_permission/ Caller: CRM_Core_Permission::assembleBasicPermissions at /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/CRM/Core/Error.php:1132



